### PR TITLE
スライダーや素材カードのデータ構造を大幅に変更

### DIFF
--- a/nuxt/components/material/card.vue
+++ b/nuxt/components/material/card.vue
@@ -2,7 +2,7 @@
   <v-card v-show="quantity !== 0" :to="localePath(`/materials/${materialId}`)" :v-slot:loader="false" color="card">
     <div class="py-2 px-3 d-flex align-center">
       <v-btn
-        v-if="items[0].purposeType === 'exp'"
+        v-if="items[0].type === 'exp'"
         color="transparent"
         class="my-n2 ml-n3"
         variant="flat"
@@ -35,43 +35,54 @@ import {BookmarkableExp, BookmarkableIngredient, BookmarkableItem} from "~/types
 import {computed} from "#imports"
 import characterIngredients from "~/assets/data/character-ingredients.yaml"
 import materials from "~/assets/data/materials.csv"
+import {db} from "~/dexie/db"
 import lightConeIngredients from "~/assets/data/light-cone-ingredients.yaml"
+import {LevelingBookmark} from "~/types/bookmark/bookmark"
 
 const props = defineProps<{
-  items: BookmarkableItem[]
+  items: BookmarkableIngredient[]
 }>()
 
 const theme = useTheme()
 
 const expDefs = computed(() => {
-  switch (props.items[0].targetType) {
-    case "character":
-      return characterIngredients.expItems
-    case "light_cone":
-      return lightConeIngredients.expItems
+  if (props.items[0].type !== "exp") {
+    return null
+  }
+
+  if (props.items[0].usage.lightConeId) {
+    return lightConeIngredients.expItems
+  } else {
+    return characterIngredients.expItems
   }
 })
 
-const selectedExpItem = ref(expDefs.value[0])
+const selectedExpItem = ref(expDefs.value?.[0] ?? null)
 
 const forwardSelectedExpItem = () => {
-  const index = expDefs.value.findIndex(e => e.itemId === selectedExpItem.value.itemId)
+  if (!expDefs.value) {
+    return
+  }
+
+  const index = expDefs.value.findIndex(e => e.itemId === selectedExpItem.value!.itemId)
   selectedExpItem.value = expDefs.value[index + 1] ?? expDefs.value[0]
 }
 
 const materialId = computed(() => {
-  if (isExpList(props.items)) {
+  if (selectedExpItem.value) {
     return selectedExpItem.value.itemId
   } else {
-    return (props.items[0] as BookmarkableIngredient).id
+    return (props.items[0] as BookmarkableItem).materialId
   }
 })
 
 const quantity = computed(() => {
-  if (isExpList(props.items)) {
-    return props.items.reduce((acc, e) => acc + Math.ceil(e.exp! / selectedExpItem.value.expPerItem), 0)
+  if (selectedExpItem.value) {
+    const items = props.items as BookmarkableExp[]
+    return items.reduce((acc, e) => acc + Math.ceil(e.exp! / selectedExpItem.value!.expPerItem), 0)
   } else {
-    return (props.items as BookmarkableIngredient[]).reduce((acc, e) => acc + e.quantity!, 0)
+    const items = props.items as BookmarkableItem[]
+    return items.reduce((acc, e) => acc + e.quantity, 0)
   }
 })
 

--- a/nuxt/components/material/cards.vue
+++ b/nuxt/components/material/cards.vue
@@ -5,10 +5,10 @@
 </template>
 
 <script lang="ts" setup>
-import {BookmarkableItem} from "~/types/bookmarkable-ingredient"
+import {BookmarkableIngredient} from "~/types/bookmarkable-ingredient"
 
 defineProps<{
-  items: BookmarkableItem[]
+  items: BookmarkableIngredient[]
 }>()
 
 </script>

--- a/nuxt/components/single-slider-panel.vue
+++ b/nuxt/components/single-slider-panel.vue
@@ -14,7 +14,7 @@
 <script lang="ts" setup>
 import {BookmarkableExp, BookmarkableIngredient, BookmarkableItem} from "~/types/bookmarkable-ingredient"
 import characterIngredients from "~/assets/data/character-ingredients.yaml"
-import {CharacterMaterialDefinitions} from "~/types/generated/characters.g"
+import {CharacterMaterialDefinitions, Path} from "~/types/generated/characters.g"
 import {LightConeMaterialDefinitions} from "~/types/generated/light-cones.g"
 import lightConeIngredients from "~/assets/data/light-cone-ingredients.yaml"
 import characters from "~/assets/data/characters.yaml"
@@ -26,6 +26,7 @@ const props = defineProps<{
   title: string
   characterId: string
   lightConeId?: string
+  variant?: Path
   materialDefs: CharacterMaterialDefinitions | LightConeMaterialDefinitions
 }>()
 
@@ -75,6 +76,7 @@ const items = computed<BookmarkableIngredient[]>(() => {
       usage = {
         type: "character",
         characterId: props.characterId,
+        variant: props.variant ?? null,
         purposeType: "ascension",
         upperLevel: e.level,
       }

--- a/nuxt/components/single-slider-panel.vue
+++ b/nuxt/components/single-slider-panel.vue
@@ -12,13 +12,7 @@
 </template>
 
 <script lang="ts" setup>
-import {
-  BookmarkableExp,
-  BookmarkableIngredient,
-  BookmarkableIngredientMeta,
-  BookmarkableItem,
-} from "~/types/bookmarkable-ingredient"
-import {TargetType} from "~/types/strings"
+import {BookmarkableExp, BookmarkableIngredient, BookmarkableItem} from "~/types/bookmarkable-ingredient"
 import characterIngredients from "~/assets/data/character-ingredients.yaml"
 import {CharacterMaterialDefinitions} from "~/types/generated/characters.g"
 import {LightConeMaterialDefinitions} from "~/types/generated/light-cones.g"
@@ -26,30 +20,28 @@ import lightConeIngredients from "~/assets/data/light-cone-ingredients.yaml"
 import characters from "~/assets/data/characters.yaml"
 import lightCones from "~/assets/data/light-cones.yaml"
 import {LevelIngredients} from "~/types/level-ingredients"
+import {Usage} from "~/types/bookmark/usage"
 
 const props = defineProps<{
   title: string
-  targetType: TargetType
-  targetId: string
+  characterId: string
+  lightConeId?: string
   materialDefs: CharacterMaterialDefinitions | LightConeMaterialDefinitions
 }>()
 
 const rarity = (() => {
-  switch (props.targetType) {
-    case "character":
-      return characters.find(e => e.id === props.targetId)!.rarity
-    case "light_cone":
-      return lightCones.find(e => e.id === props.targetId)!.rarity
+  if (props.lightConeId) {
+    return lightCones.find(e => e.id === props.lightConeId)!.rarity
+  } else {
+    return characters.find(e => e.id === props.characterId)!.rarity
   }
 })()
 
 const levelIngredients = (() => {
-  switch (props.targetType) {
-    case "character":
-      return levelsToLevelIngredients(characterIngredients.purposeTypes.ascension.levels)
-    case "light_cone": {
-      return levelsToLevelIngredients(lightConeIngredients.levels)
-    }
+  if (props.lightConeId) {
+    return levelsToLevelIngredients(lightConeIngredients.levels)
+  } else {
+    return levelsToLevelIngredients(characterIngredients.purposeTypes.ascension.levels)
   }
 })()
 
@@ -61,28 +53,62 @@ const ingredientsWithinSelectedLevelRange = computed<LevelIngredients[]>(() => {
   return levelIngredients.filter(e => range.value[0] < e.level && e.level <= range.value[1])
 })
 
-const items = computed<BookmarkableItem[]>(() => {
-  return ingredientsWithinSelectedLevelRange.value.map(e => e.ingredients.map<BookmarkableItem>((f) => {
-    const meta: BookmarkableIngredientMeta = {
-      level: e.level,
-      targetType: props.targetType,
-      targetId: props.targetId,
+const items = computed<BookmarkableIngredient[]>(() => {
+  return ingredientsWithinSelectedLevelRange.value.map(e => e.ingredients.map<BookmarkableIngredient>((f) => {
+    let usage: Usage
+    if (f.exp) {
+      usage = {
+        type: "exp",
+        characterId: props.characterId,
+        lightConeId: props.lightConeId,
+        upperLevel: e.level,
+      }
+    } else if (props.lightConeId) {
+      usage = {
+        type: "light_cone",
+        characterId: props.characterId,
+        lightConeId: props.lightConeId,
+        purposeType: "ascension",
+        upperLevel: e.level,
+      }
+    } else {
+      usage = {
+        type: "character",
+        characterId: props.characterId,
+        purposeType: "ascension",
+        upperLevel: e.level,
+      }
     }
 
-    if (typeof f.quantity !== "undefined") {
-      const result: BookmarkableIngredient = {
-        id: getMaterialIdFromIngredient(f, props.materialDefs),
-        quantity: f.quantity.rarities[rarity.toString()],
-        ...meta,
-        purposeType: "ascension",
+    if (usage.type === "exp") {
+      const result: BookmarkableExp = {
+        type: "exp",
+        exp: f.exp!.rarities[rarity.toString()],
+        usage,
       }
       return result
     } else {
-      const result: BookmarkableExp = {
-        exp: f.exp!.rarities[rarity.toString()],
-        ...meta,
-        purposeType: "exp",
+      if (!f.quantity) {
+        throw new Error("Invalid ingredient markup")
       }
+
+      let result: BookmarkableItem
+      if (usage.type === "character") {
+        result = {
+          type: "character_material",
+          materialId: getMaterialIdFromIngredient(f, props.materialDefs),
+          quantity: f.quantity.rarities[rarity.toString()],
+          usage,
+        }
+      } else {
+        result = {
+          type: "light_cone_material",
+          materialId: getMaterialIdFromIngredient(f, props.materialDefs),
+          quantity: f.quantity.rarities[rarity.toString()],
+          usage,
+        }
+      }
+
       return result
     }
   })).flat()

--- a/nuxt/components/skill-sliders-panel.vue
+++ b/nuxt/components/skill-sliders-panel.vue
@@ -61,6 +61,7 @@ const ingredients = computed<BookmarkableItem[]>(() => {
         quantity: g.quantity!.rarities[characterRarity.toString()],
         usage: {
           type: "character",
+          variant: props.variant ?? null,
           upperLevel: f.level,
           characterId: props.characterId,
           purposeType: e.type,

--- a/nuxt/components/skill-sliders-panel.vue
+++ b/nuxt/components/skill-sliders-panel.vue
@@ -15,11 +15,11 @@ interface Slider {
 const props = defineProps<{
   title: string
   characterId: string
-  variantPath?: Path
+  variant?: Path
   materialDefs: CharacterMaterialDefinitions
 }>()
 
-const skillI18nKeyBase = computed(() => `skillTitles.${props.characterId + (props.variantPath ? `.${props.variantPath}` : "")}`)
+const skillI18nKeyBase = computed(() => `skillTitles.${props.characterId + (props.variant ? `.${props.variant}` : "")}`)
 
 const sliders: Slider[] = [
   {

--- a/nuxt/components/skill-sliders-panel.vue
+++ b/nuxt/components/skill-sliders-panel.vue
@@ -1,14 +1,14 @@
 <script lang="ts" setup>
 import {computed, getMaterialIdFromIngredient, levelIngredientsToSliderTicks, ref} from "#imports"
 import characterIngredients from "~/assets/data/character-ingredients.yaml"
-import {BookmarkableIngredient} from "~/types/bookmarkable-ingredient"
+import {BookmarkableItem} from "~/types/bookmarkable-ingredient"
 import {PurposeType} from "~/types/strings"
 import {CharacterMaterialDefinitions, Path} from "~/types/generated/characters.g"
 import {LevelIngredients} from "~/types/level-ingredients"
 import characters from "~/assets/data/characters.yaml"
 
 interface Slider {
-  type: Exclude<PurposeType, "exp">
+  type: PurposeType
   levelIngredients: LevelIngredients[]
 }
 
@@ -49,19 +49,22 @@ const ranges = ref(sliders.map((e) => {
 
 const checkedList = ref(sliders.map(() => true))
 
-const ingredients = computed<BookmarkableIngredient[]>(() => {
+const ingredients = computed<BookmarkableItem[]>(() => {
   return sliders.map((e, i) => {
     if (!checkedList.value[i]) {
       return []
     }
     return e.levelIngredients.filter(f => ranges.value[i][0] < f.level && f.level <= ranges.value[i][1])
-      .map(f => f.ingredients.map<BookmarkableIngredient>(g => ({
-        id: getMaterialIdFromIngredient(g, props.materialDefs)!,
+      .map(f => f.ingredients.map<BookmarkableItem>(g => ({
+        type: "character_material",
+        materialId: getMaterialIdFromIngredient(g, props.materialDefs)!,
         quantity: g.quantity!.rarities[characterRarity.toString()],
-        level: f.level,
-        targetType: "character",
-        targetId: props.characterId,
-        purposeType: e.type,
+        usage: {
+          type: "character",
+          upperLevel: f.level,
+          characterId: props.characterId,
+          purposeType: e.type,
+        },
       }))).flat()
   }).flat()
 })

--- a/nuxt/pages/characters/[characterId].vue
+++ b/nuxt/pages/characters/[characterId].vue
@@ -16,19 +16,19 @@ if (!characters.some(e => e.id === route.params.characterId)) {
 
 const character = characters.find(e => e.id === route.params.characterId)!
 
-const selectedVariant = ref<CharacterVariant>(character.variants?.[0] ?? {
+const currentVariant = ref<CharacterVariant>(character.variants?.[0] ?? {
   path: character.path!,
   combatType: character.combatType!,
   materials: character.materials!,
 })
 
-watch(selectedVariant, (value) => {
+watch(currentVariant, (value) => {
   history.replaceState(null, "", router.resolve({query: {variant: value.path}}).href)
 })
 
 onActivated(() => {
   if (character.variants && route.query.variant) {
-    selectedVariant.value = character.variants.find(e => e.path === route.query.variant) ?? selectedVariant.value
+    currentVariant.value = character.variants.find(e => e.path === route.query.variant) ?? currentVariant.value
   }
 })
 
@@ -47,19 +47,19 @@ onActivated(() => {
         <div class="d-flex align-center">
           <span class="font-weight-bold">{{ tx("common.path") }}</span>
           <v-img
-            :src="getPathImage(selectedVariant.path)"
+            :src="getPathImage(currentVariant.path)"
             :style="!$vuetify.theme.global.current.dark ? 'filter: invert(1)' : ''"
             aspect-ratio="1"
             class="ml-3"
             max-width="22px"
             width="22px"
           />
-          <span class="ml-1">{{ tx(`paths.${selectedVariant.path}` as const) }}</span>
+          <span class="ml-1">{{ tx(`paths.${currentVariant.path}` as const) }}</span>
         </div>
         <div class="d-flex align-center">
           <span class="font-weight-bold">{{ tx("common.combatType") }}</span>
-          <v-img :src="getCombatTypeImage(selectedVariant.combatType)" class="ml-3" max-width="22px" width="22px" />
-          <span class="ml-1">{{ tx(`combatTypes.${selectedVariant.combatType}` as const) }}</span>
+          <v-img :src="getCombatTypeImage(currentVariant.combatType)" class="ml-3" max-width="22px" width="22px" />
+          <span class="ml-1">{{ tx(`combatTypes.${currentVariant.combatType}` as const) }}</span>
         </div>
       </div>
     </v-row>
@@ -67,7 +67,7 @@ onActivated(() => {
     <client-only>
       <v-select
         v-if="character.variants"
-        v-model="selectedVariant"
+        v-model="currentVariant"
         :items="character.variants.map(e => ({title: tx(`paths.${e.path}` as const), value: e}))"
         :label="tx('common.path')"
         class="mt-4"
@@ -78,15 +78,15 @@ onActivated(() => {
 
     <v-expansion-panels class="mt-4" mandatory="force">
       <SingleSliderPanel
-        :material-defs="selectedVariant.materials"
+        :material-defs="currentVariant.materials"
         :character-id="character.id"
         :title="tx( 'characterDetailsPage.ascension')"
       />
       <SkillSlidersPanel
         :character-id="character.id"
-        :material-defs="selectedVariant.materials"
+        :material-defs="currentVariant.materials"
         :title="tx('characterDetailsPage.skills')"
-        :variant-path="character.variants ? selectedVariant.path : undefined"
+        :variant-path="character.variants ? currentVariant.path : undefined"
       />
     </v-expansion-panels>
   </div>

--- a/nuxt/pages/characters/[characterId].vue
+++ b/nuxt/pages/characters/[characterId].vue
@@ -79,9 +79,8 @@ onActivated(() => {
     <v-expansion-panels class="mt-4" mandatory="force">
       <SingleSliderPanel
         :material-defs="selectedVariant.materials"
-        :target-id="character.id"
+        :character-id="character.id"
         :title="tx( 'characterDetailsPage.ascension')"
-        target-type="character"
       />
       <SkillSlidersPanel
         :character-id="character.id"

--- a/nuxt/pages/characters/[characterId].vue
+++ b/nuxt/pages/characters/[characterId].vue
@@ -86,7 +86,7 @@ onActivated(() => {
         :character-id="character.id"
         :material-defs="currentVariant.materials"
         :title="tx('characterDetailsPage.skills')"
-        :variant-path="character.variants ? currentVariant.path : undefined"
+        :variant="character.variants ? currentVariant.path : undefined"
       />
     </v-expansion-panels>
   </div>

--- a/nuxt/pages/characters/[characterId].vue
+++ b/nuxt/pages/characters/[characterId].vue
@@ -80,6 +80,7 @@ onActivated(() => {
       <SingleSliderPanel
         :material-defs="currentVariant.materials"
         :character-id="character.id"
+        :variant="character.variants ? currentVariant.path : undefined"
         :title="tx( 'characterDetailsPage.ascension')"
       />
       <SkillSlidersPanel

--- a/nuxt/pages/light-cones/[lightConeId].vue
+++ b/nuxt/pages/light-cones/[lightConeId].vue
@@ -44,10 +44,9 @@ const lightCone = lightCones.find(e => e.id === route.params.lightConeId)!
     <v-expansion-panels class="mt-4" mandatory="force">
       <SingleSliderPanel
         :material-defs="lightCone.materials"
-        :rarity="lightCone.rarity"
         :title="tx('lightConeDetailsPage.ascension')"
-        target-type="light_cone"
-        :target-id="lightCone.id"
+        :light-cone-id="lightCone.id"
+        character-id="march-7th"
       />
 
       <v-expansion-panel :title="tx('lightConeDetailsPage.skillDescriptions')">

--- a/nuxt/types/bookmark/bookmark.ts
+++ b/nuxt/types/bookmark/bookmark.ts
@@ -1,0 +1,63 @@
+import {Stat} from "~/types/generated/relic-stats.g"
+import {Usage} from "~/types/bookmark/usage"
+
+export type Bookmark =
+  | Bookmark.CharacterMaterial
+  | Bookmark.LightConeMaterial
+  | Bookmark.Exp
+  | Bookmark.RelicSet
+  | Bookmark.RelicPiece
+
+export type LevelingBookmark = Bookmark.CharacterMaterial | Bookmark.LightConeMaterial | Bookmark.Exp
+
+export namespace Bookmark {
+  export interface CharacterMaterial {
+    id?: number
+    type: "character_material"
+    bookmarkedAt: Date
+    materialId: string
+    usage: Usage.Character
+    quantity: number
+  }
+
+  export interface LightConeMaterial {
+    id?: number
+    type: "light_cone_material"
+    bookmarkedAt: Date
+    materialId: string
+    usage: Usage.LightCone
+    quantity: number
+  }
+
+  export interface Exp {
+    id?: number
+    type: "exp"
+    bookmarkedAt: Date
+    usage: Usage.Exp
+    exp: number
+    selectedItem: string
+  }
+
+  export interface RelicSet {
+    id?: number
+    type: "relic_set"
+    bookmarkedAt: Date
+    characterId: string
+    relicSetIds: string[]
+    mainStats: {
+      body: Stat[]
+      feet: Stat[]
+    }
+    subStats: Stat[]
+  }
+
+  export interface RelicPiece {
+    id?: number
+    type: "relic_piece"
+    bookmarkedAt: Date
+    relicPieceId: string
+    characterId: string
+    mainStat: Stat | null
+    subStats: Stat[]
+  }
+}

--- a/nuxt/types/bookmark/usage.ts
+++ b/nuxt/types/bookmark/usage.ts
@@ -1,0 +1,27 @@
+import {PurposeType} from "~/types/strings"
+
+export type Usage = Usage.Character | Usage.LightCone | Usage.Exp
+
+export namespace Usage {
+  export interface Character {
+    type: "character"
+    characterId: string
+    purposeType: PurposeType
+    upperLevel: number
+  }
+
+  export interface LightCone {
+    type: "light_cone"
+    characterId: string
+    lightConeId: string
+    purposeType: PurposeType & "ascension"
+    upperLevel: number
+  }
+
+  export interface Exp {
+    type: "exp"
+    characterId: string
+    lightConeId?: string
+    upperLevel: number
+  }
+}

--- a/nuxt/types/bookmark/usage.ts
+++ b/nuxt/types/bookmark/usage.ts
@@ -1,4 +1,5 @@
 import {PurposeType} from "~/types/strings"
+import {Path} from "~/types/generated/characters.g"
 
 export type Usage = Usage.Character | Usage.LightCone | Usage.Exp
 
@@ -6,6 +7,7 @@ export namespace Usage {
   export interface Character {
     type: "character"
     characterId: string
+    variant: Path | null
     purposeType: PurposeType
     upperLevel: number
   }

--- a/nuxt/types/bookmarkable-ingredient.ts
+++ b/nuxt/types/bookmarkable-ingredient.ts
@@ -1,20 +1,14 @@
-import {PurposeType, TargetType} from "~/types/strings"
+import {Bookmark} from "~/types/bookmark/bookmark"
 
-export interface BookmarkableIngredientMeta {
-  level: number
-  targetId: string
-  targetType: TargetType
-}
+export type BookmarkableCharacterMaterial = Omit<Bookmark.CharacterMaterial, "id" | "bookmarkedAt">
 
-export interface BookmarkableIngredient extends BookmarkableIngredientMeta {
-  id: string
-  quantity: number
-  purposeType: Exclude<PurposeType, "exp">
-}
+export type BookmarkableLightConeMaterial = Omit<Bookmark.LightConeMaterial, "id" | "bookmarkedAt">
 
-export interface BookmarkableExp extends BookmarkableIngredientMeta {
-  exp: number
-  purposeType: PurposeType & "exp"
-}
+export type BookmarkableExp = Omit<Bookmark.Exp, "id" | "bookmarkedAt" | "selectedItem">
 
-export type BookmarkableItem = BookmarkableIngredient | BookmarkableExp
+export type BookmarkableItem = BookmarkableCharacterMaterial | BookmarkableLightConeMaterial
+
+export type BookmarkableIngredient =
+  | BookmarkableCharacterMaterial
+  | BookmarkableLightConeMaterial
+  | BookmarkableExp

--- a/nuxt/types/strings.ts
+++ b/nuxt/types/strings.ts
@@ -2,6 +2,4 @@ import {CharacterIngredients} from "~/types/generated/character-ingredients.g"
 
 export type ThemeSetting = "dark" | "light" | "auto"
 
-export type TargetType = "character" | "light_cone"
-
-export type PurposeType = keyof CharacterIngredients["purposeTypes"] | "exp"
+export type PurposeType = keyof CharacterIngredients["purposeTypes"]

--- a/nuxt/utils/merge-items.ts
+++ b/nuxt/utils/merge-items.ts
@@ -1,24 +1,24 @@
-import {BookmarkableItem} from "~/types/bookmarkable-ingredient"
 import materials from "~/assets/data/materials.csv"
+import {BookmarkableIngredient} from "~/types/bookmarkable-ingredient"
 
 /**
  * Merges items in the list with the same material IDs and returns an array of arrays.
  *
  * If the item is an exp item, it will be merged into another exp item.
  *
- * @param items The {@link BookmarkableItem} list to merge
- * @returns The merged {@link BookmarkableItem} list
+ * @param items The {@link BookmarkableIngredient} list to merge
+ * @returns The merged {@link BookmarkableIngredient} list
  */
-export const mergeItems = (items: BookmarkableItem[]): BookmarkableItem[][] => {
-  const result: BookmarkableItem[][] = []
+export const mergeItems = (items: BookmarkableIngredient[]): BookmarkableIngredient[][] => {
+  const result: BookmarkableIngredient[][] = []
   for (const item of items) {
     const existing = (() => {
-      if (item.purposeType === "exp") {
+      if (item.type === "exp") {
         // If the item is an exp item, add into existing exp item (exp item does not have id)
-        return result.find(e => e[0].purposeType === "exp")
+        return result.find(e => e[0].type === "exp")
       } else {
         // If the item has an id, add into existing item has the same id
-        return result.find(e => e[0].purposeType !== "exp" && e[0]?.id === item.id)
+        return result.find(e => e[0].type !== "exp" && e[0].materialId === item.materialId)
       }
     })()
     if (existing) {
@@ -41,13 +41,13 @@ export const mergeItems = (items: BookmarkableItem[]): BookmarkableItem[][] => {
     const aElement = a[0]
     const bElement = b[0]
 
-    if (aElement.purposeType === "exp" || bElement.purposeType === "exp") {
-      return aElement.purposeType === "exp" ? -1 : 1
-    } else if (aElement.id === "credit" || bElement.id === "credit") {
-      return aElement.id === "credit" ? 1 : -1
+    if (aElement.type === "exp" || bElement.type === "exp") {
+      return aElement.type === "exp" ? -1 : 1
+    } else if (aElement.materialId === "credit" || bElement.materialId === "credit") {
+      return aElement.materialId === "credit" ? 1 : -1
     } else {
-      const aMaterial = materials.find(e => e.id === aElement.id)!
-      const bMaterial = materials.find(e => e.id === bElement.id)!
+      const aMaterial = materials.find(e => e.id === aElement.materialId)!
+      const bMaterial = materials.find(e => e.id === bElement.materialId)!
       if (aMaterial.groupId && bMaterial.groupId) {
         if (aMaterial.groupId !== bMaterial.groupId) {
           return aMaterial.groupId.localeCompare(bMaterial.groupId)
@@ -57,7 +57,7 @@ export const mergeItems = (items: BookmarkableItem[]): BookmarkableItem[][] => {
       } else if (aMaterial.groupId || bMaterial.groupId) {
         return aMaterial.groupId ? -1 : 1
       } else {
-        return aElement.id.localeCompare(bElement.id)
+        return aElement.materialId.localeCompare(bElement.materialId)
       }
     }
   })


### PR DESCRIPTION
- ブックマーク保存用のInterface追加
- スライダーや素材カードに渡すデータもそれに依存した形式に変更
- `targetType` `targetId`を廃止し、`characterId`を常に渡し、`lightConeId`の有無でキャラか光円錐か判別する。
- EXP用のinterfaceを完全に分離し、別枠で処理することで扱いやすく