### PR TITLE
yarn generate 時にエラーが発生する問題の修正

### DIFF
--- a/nuxt/utils/merge-items.ts
+++ b/nuxt/utils/merge-items.ts
@@ -1,4 +1,4 @@
-import {isArray} from "lodash"
+import _ from "lodash"
 import materials from "~/assets/data/materials.csv"
 import {BookmarkableIngredient, isBookmarkableExp} from "~/types/bookmarkable-ingredient"
 
@@ -42,8 +42,8 @@ export const mergeItems = (items: BookmarkableIngredient[]): BookmarkableIngredi
 }
 
 export const materialSortFunc = (a: BookmarkableIngredient | BookmarkableIngredient[], b: BookmarkableIngredient | BookmarkableIngredient[]): number => {
-  const aElement = isArray(a) ? a[0] : a
-  const bElement = isArray(b) ? b[0] : b
+  const aElement = _.isArray(a) ? a[0] : a
+  const bElement = _.isArray(b) ? b[0] : b
 
   if (isBookmarkableExp(aElement) || isBookmarkableExp(bElement)) {
     return isBookmarkableExp(aElement) ? -1 : 1


### PR DESCRIPTION
## 原因

lodashのインポート方法の間違い

## エラーメッセージ

```
[11:59:38 PM]  ERROR  Named export 'isArray' not found. The requested module 'file:///Users/chika/Documents/IdeaProjects/hsr-material/nuxt/node_modules/lodash/lodash.js' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'file:///Users/chika/Documents/IdeaProjects/hsr-material/nuxt/node_modules/lodash/lodash.js';
const { isArray } = pkg;


  import { isArray } from 'node_modules/lodash/lodash.js';
  ^^^^^^^
  SyntaxError: Named export 'isArray' not found. The requested module 'node_modules/lodash/lodash.js' is a CommonJS module, which may not support all module.exports as named exports.
  CommonJS modules can always be imported via the default export, for example using:
  
  import pkg from 'node_modules/lodash/lodash.js';
  const { isArray } = pkg;
  
  at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
  at async ModuleJob.run (node:internal/modules/esm/module_job:190:5)

  ├─ /characters/dan-heng (7ms) (Error: [500] )                
```