### PR TITLE
昇格スライダーの初期値にEXPアイテムが考慮されない場合がある問題の修正

### DIFF
--- a/nuxt/components/single-slider-panel.vue
+++ b/nuxt/components/single-slider-panel.vue
@@ -85,6 +85,7 @@ const ingredientsToBookmarkableIngredients = (ingredients: LevelIngredients[]): 
         characterId: props.characterId,
         variant: props.variant,
         lightConeId: props.lightConeId,
+        purposeType: "ascension",
         upperLevel: e.level,
       }
     } else if (props.lightConeId) {

--- a/nuxt/components/skill-sliders-panel.vue
+++ b/nuxt/components/skill-sliders-panel.vue
@@ -47,6 +47,7 @@ const ranges = ref(sliders.map((e) => {
   const sliderTicks = levelIngredientsToSliderTicks(e.levelIngredients)
   return [sliderTicks[0], sliderTicks.slice(-1)[0]]
 }))
+const checkedList = ref(sliders.map(() => true))
 const setInitialRangeBasedOnBookmarks = async() => {
   for (const i in sliders) {
     const slider = sliders[i]
@@ -59,6 +60,7 @@ const setInitialRangeBasedOnBookmarks = async() => {
     )
 
     if (bookmarks.length === 0) {
+      checkedList.value[i] = false
       continue
     }
 
@@ -69,12 +71,14 @@ const setInitialRangeBasedOnBookmarks = async() => {
 
     ranges.value[i] = [sliderTicks[sliderTicks.indexOf(min) - 1], max]
   }
+
+  if (checkedList.value.every(e => !e)) {
+    checkedList.value = sliders.map(() => true)
+  }
 }
 onMounted(() => {
   setInitialRangeBasedOnBookmarks()
 })
-
-const checkedList = ref(sliders.map(() => true))
 
 const ingredients = computed<BookmarkableItem[]>(() => {
   return sliders.map((e, i) => {

--- a/nuxt/dexie/db.ts
+++ b/nuxt/dexie/db.ts
@@ -88,14 +88,10 @@ export class MySubClassedDexie extends Dexie {
 
         switch (item.type) {
           case "character_exp":
-            // filtered by characterId and variant
-            return true
           case "character_material":
             // filtered by characterId, variant, and purposeType
             return item.usage.purposeType === purposeType
           case "light_cone_exp":
-            // filtered by characterId, variant, and lightConeId
-            return item.usage.lightConeId === lightConeId
           case "light_cone_material":
             // filtered by characterId, variant, lightConeId, and purposeType
             return item.usage.lightConeId === lightConeId && item.usage.purposeType === purposeType

--- a/nuxt/types/bookmark/usage.ts
+++ b/nuxt/types/bookmark/usage.ts
@@ -26,7 +26,7 @@ export namespace Usage {
     characterId: string
     variant: Path | null
     lightConeId?: string
-    purposeType?: undefined
+    purposeType: PurposeType & "ascension"
     upperLevel: number
   }
 }


### PR DESCRIPTION
EXPアイテムの`usage.purposeType`として、`ascension`を登録するように。意味合いとしては若干異なるが、一緒にしてしまっても大きな問題はない(区別可能)と判断。