### PR TITLE
試験的に dispatchGetWarpHistory 関数の最小インスタンス数を1に設定

### DIFF
--- a/firebase/functions/src/funcs/dispatch-get-warp-history.ts
+++ b/firebase/functions/src/funcs/dispatch-get-warp-history.ts
@@ -9,6 +9,8 @@ export const dispatchGetWarpHistory = functions
   .region("asia-northeast1")
   .runWith({
     memory: "1GB",
+    minInstances: 1,
+    maxInstances: 5,
   })
   .https.onCall((data: DispatchGetWarpHistoryParams, context): Promise<DispatchGetWarpHistoryResult> => {
     if (!context.app) {


### PR DESCRIPTION
## 目的

コールドスタートを抑える目的で設定。

## 懸念点

課金される。概算で月300円ほど。

https://cloud.google.com/functions/pricing?hl=ja#idle