### PR TITLE
Cloud Functions のメモリ・最小インスタンス数変更

### DIFF
--- a/firebase/functions/src/funcs/dispatch-get-warp-history.ts
+++ b/firebase/functions/src/funcs/dispatch-get-warp-history.ts
@@ -8,9 +8,7 @@ import {warpHistoryTicketConverter} from "../utils/warp-history-ticket-converter
 export const dispatchGetWarpHistory = functions
   .region("asia-northeast1")
   .runWith({
-    memory: "1GB",
     minInstances: 1,
-    maxInstances: 5,
   })
   .https.onCall((data: DispatchGetWarpHistoryParams, context): Promise<DispatchGetWarpHistoryResult> => {
     if (!context.app) {

--- a/firebase/functions/src/funcs/get-warp-history.ts
+++ b/firebase/functions/src/funcs/get-warp-history.ts
@@ -5,7 +5,7 @@ import {GetWarpHistoryParams} from "../types/get-warp-history-params"
 export const getWarpHistory = functions
   .region("asia-northeast1")
   .runWith({
-    memory: "1GB",
+    minInstances: 1,
   })
   .tasks.taskQueue({
     rateLimits: {


### PR DESCRIPTION
- `getWarpHistory`(クラウドタスク)のメモリを256MB(デフォルト)に戻し、最小インスタンス数を1に設定。
- `dispatchGetWarpHistory`のメモリをを256MB(デフォルト)に戻し、最大インスタンス数の設定を削除

これによりコールドスタートが無くなり爆速で実行できる代わり、月330円程度の課金が発生することになる。試験的にこれで運用してみる。