### PR TITLE
getWarpHistory 関数の最小インスタンス数設定削除

### DIFF
--- a/firebase/functions/src/funcs/get-warp-history.ts
+++ b/firebase/functions/src/funcs/get-warp-history.ts
@@ -4,9 +4,6 @@ import {GetWarpHistoryParams} from "../types/get-warp-history-params"
 
 export const getWarpHistory = functions
   .region("asia-northeast1")
-  .runWith({
-    minInstances: 1,
-  })
   .tasks.taskQueue({
     rateLimits: {
       maxConcurrentDispatches: 5,


### PR DESCRIPTION
dispatch関数のみに設定するだけで十分高速化されることがわかったため、コスト削減のため設定を削除