### PR TITLE
feat: DBからbookmarkedCharactersテーブルを削除 (DBスキーマの変更)

### DIFF
--- a/nuxt/components/bookmark/details-dialog.vue
+++ b/nuxt/components/bookmark/details-dialog.vue
@@ -39,7 +39,7 @@ const purposes = computed(() => {
 })
 
 const getSkillTitle = (item: LevelingBookmark) => {
-  return tx(i18n, `skillTitles.${toCharacterIdWithVariant(item.usage.characterId, item.usage.variant).replace("_", ".")}.${item.usage.purposeType}`)
+  return tx(i18n, `skillTitles.${item.characterId.replace("_", ".")}.${item.usage.purposeType}`)
 }
 
 const removeBookmarksInLevel = (purposeType: PurposeType, level: number) => {

--- a/nuxt/components/bookmark/list.vue
+++ b/nuxt/components/bookmark/list.vue
@@ -3,28 +3,30 @@
 
 import {useObservable} from "@vueuse/rxjs"
 import {liveQuery} from "dexie"
-import {BookmarkCharacter} from "~/types/bookmark/bookmark-character"
+import _ from "lodash"
 import {Bookmark} from "~/types/bookmark/bookmark"
 import {_db} from "~/dexie/db"
 
-const bookmarkCharacters = useObservable<BookmarkCharacter[], BookmarkCharacter[]>(liveQuery(() => _db.bookmarkCharacters.toArray()) as any, {
-  initialValue: [],
-})
 const bookmarks = useObservable<Bookmark[], Bookmark[]>(liveQuery(() => _db.bookmarks.toArray()) as any, {
   initialValue: [],
 })
+
+const bookmarkCharacters = computed(() => {
+  return _.groupBy(bookmarks.value, v => v.characterId)
+})
+
 </script>
 
 <template>
   <div class="bookmark-cards-wrapper">
     <BookmarkCharacterCard
-      v-for="character in bookmarkCharacters"
-      :key="character.characterId"
-      :bookmarks="bookmarks.filter(e => character.bookmarks.includes(e.id!))"
-      :character="character.characterId"
+      v-for="(characterBookmarks, characterId) in bookmarkCharacters"
+      :key="characterId"
+      :bookmarks="characterBookmarks"
+      :character="characterId"
     />
 
-    <div v-if="bookmarkCharacters.length === 0" class="no-bookmarks">
+    <div v-if="Object.keys(bookmarkCharacters).length === 0" class="no-bookmarks">
       {{ tx("bookmark.noBookmarks") }}
     </div>
   </div>

--- a/nuxt/components/single-slider-panel.vue
+++ b/nuxt/components/single-slider-panel.vue
@@ -82,8 +82,6 @@ const ingredientsToBookmarkableIngredients = (ingredients: LevelIngredients[]): 
     if (f.exp) {
       usage = {
         type: "exp",
-        characterId: props.characterId,
-        variant: props.variant,
         lightConeId: props.lightConeId ?? null,
         purposeType: "ascension",
         upperLevel: e.level,
@@ -91,8 +89,6 @@ const ingredientsToBookmarkableIngredients = (ingredients: LevelIngredients[]): 
     } else if (props.lightConeId) {
       usage = {
         type: "light_cone",
-        characterId: props.characterId,
-        variant: props.variant,
         lightConeId: props.lightConeId,
         purposeType: "ascension",
         upperLevel: e.level,
@@ -100,8 +96,6 @@ const ingredientsToBookmarkableIngredients = (ingredients: LevelIngredients[]): 
     } else {
       usage = {
         type: "character",
-        characterId: props.characterId,
-        variant: props.variant,
         purposeType: "ascension",
         upperLevel: e.level,
       }
@@ -110,6 +104,7 @@ const ingredientsToBookmarkableIngredients = (ingredients: LevelIngredients[]): 
     if (usage.type === "exp") {
       const result: BookmarkableExp = {
         type: props.lightConeId ? "light_cone_exp" : "character_exp",
+        characterId: toCharacterIdWithVariant(props.characterId, props.variant),
         exp: f.exp!.rarities[rarity.toString()],
         usage,
       }
@@ -123,6 +118,7 @@ const ingredientsToBookmarkableIngredients = (ingredients: LevelIngredients[]): 
       if (usage.type === "character") {
         result = {
           type: "character_material",
+          characterId: toCharacterIdWithVariant(props.characterId, props.variant),
           materialId: getMaterialIdFromIngredient(f, props.materialDefs),
           quantity: f.quantity.rarities[rarity.toString()],
           usage,
@@ -130,6 +126,7 @@ const ingredientsToBookmarkableIngredients = (ingredients: LevelIngredients[]): 
       } else {
         result = {
           type: "light_cone_material",
+          characterId: toCharacterIdWithVariant(props.characterId, props.variant),
           materialId: getMaterialIdFromIngredient(f, props.materialDefs),
           quantity: f.quantity.rarities[rarity.toString()],
           usage,

--- a/nuxt/components/skill-sliders-panel.vue
+++ b/nuxt/components/skill-sliders-panel.vue
@@ -88,13 +88,12 @@ const ingredients = computed<BookmarkableItem[]>(() => {
     return e.levelIngredients.filter(f => ranges.value[i][0] < f.level && f.level <= ranges.value[i][1])
       .map(f => f.ingredients.map<BookmarkableItem>(g => ({
         type: "character_material",
+        characterId: toCharacterIdWithVariant(props.characterId, props.variant),
         materialId: getMaterialIdFromIngredient(g, props.materialDefs)!,
         quantity: g.quantity!.rarities[characterRarity.toString()],
         usage: {
           type: "character",
-          variant: props.variant,
           upperLevel: f.level,
-          characterId: props.characterId,
           purposeType: e.type,
         },
       }))).flat()

--- a/nuxt/dexie/db.ts
+++ b/nuxt/dexie/db.ts
@@ -1,16 +1,11 @@
 import Dexie, {Table} from "dexie"
 import {Warp} from "#shared/warp"
-import {BookmarkCharacter} from "~/types/bookmark/bookmark-character"
 import {Bookmark} from "~/types/bookmark/bookmark"
 import {SyncedUserData, UserDocument} from "~/types/firestore/user-document"
 import {DataSyncError} from "~/libs/data-sync-error"
 import {migrate} from "~/utils/migrate"
 
 export class MySubClassedDexie extends Dexie {
-  /**
-   * Characters that have bookmarks (for redundancy)
-   */
-  bookmarkCharacters!: Table<BookmarkCharacter>
   bookmarks!: Table<Bookmark>
   warps!: Table<Warp>
 

--- a/nuxt/dexie/db.ts
+++ b/nuxt/dexie/db.ts
@@ -21,6 +21,13 @@ export class MySubClassedDexie extends Dexie {
       bookmarks: "++id, usage.characterId",
       warps: "id, gachaType",
     })
+
+    this.version(2).stores({
+      bookmarkCharacters: null,
+      bookmarks: "++id, characterId",
+    }).upgrade(async() => {
+      await this.import(migrate(await this.dump(), 1, 2))
+    })
   }
 
   dump() {

--- a/nuxt/libs/db/bookmarks-provider.ts
+++ b/nuxt/libs/db/bookmarks-provider.ts
@@ -38,10 +38,10 @@ export class BookmarksProvider extends DbProvider {
   getLevelingItems(items: BookmarkableIngredient[], purposeTypes: PurposeType[], upperLevel?: number) {
     const firstItem = items[0]
     // query all bookmarks with the same characterId
-    return this.bookmarks.where("usage.characterId").equals(firstItem.usage.characterId)
+    return this.bookmarks.where("characterId").equals(firstItem.characterId)
       .and((e) => {
-        // filter by type and variant
-        if (e.type !== firstItem.type || e.usage.variant !== firstItem.usage.variant) {
+        // filter by type
+        if (e.type !== firstItem.type) {
           return false
         }
 
@@ -77,13 +77,9 @@ export class BookmarksProvider extends DbProvider {
   }
 
   getByPurpose(characterId: string, variant: string | null, lightConeId: string | undefined, purposeType: PurposeType) {
-    return this.bookmarks.where("usage.characterId").equals(characterId)
+    return this.bookmarks.where("characterId").equals(toCharacterIdWithVariant(characterId, variant))
       .and((e) => {
         const item = e as BookmarkableIngredient
-
-        if (item.usage.variant !== variant) {
-          return false
-        }
 
         switch (item.type) {
           case "character_exp":
@@ -125,7 +121,7 @@ export class BookmarksProvider extends DbProvider {
       const ids = (await this.bookmarks.bulkAdd(dataToSave, {allKeys: true})) as number[]
 
       // add bookmark ids to bookmarkCharacters
-      const characterId = toCharacterIdWithVariant(data[0].usage.characterId, data[0].usage.variant)
+      const characterId = data[0].characterId
       const bookmarkCharacter = await this.bookmarkCharacters.get(characterId)
       if (bookmarkCharacter) {
         await this.bookmarkCharacters.update(characterId, {

--- a/nuxt/libs/db/bookmarks-provider.ts
+++ b/nuxt/libs/db/bookmarks-provider.ts
@@ -1,6 +1,5 @@
 import {Table} from "dexie"
 import {Bookmark, LevelingBookmark, RelicBookmark} from "~/types/bookmark/bookmark"
-import {BookmarkCharacter} from "~/types/bookmark/bookmark-character"
 import {BookmarkableRelic} from "~/types/bookmarkable-relic"
 import {
   BookmarkableCharacterMaterial,
@@ -18,12 +17,10 @@ import {DbProvider} from "~/libs/db/db-provider"
  */
 export class BookmarksProvider extends DbProvider {
   bookmarks: Table<Bookmark>
-  bookmarkCharacters: Table<BookmarkCharacter>
 
   constructor() {
     super()
     this.bookmarks = _db.bookmarks
-    this.bookmarkCharacters = _db.bookmarkCharacters
   }
 
   /**
@@ -95,13 +92,13 @@ export class BookmarksProvider extends DbProvider {
   }
 
   /**
-   * Adds {@link LevelingBookmark}s to the database. Also adds bookmark ids to {@link BookmarkCharacter}.
+   * Adds {@link LevelingBookmark}s to the database.
    *
    * @param data List of {@link LevelingBookmark}s to add
    * @param selectedItem Selected item (only for exp)
    */
   addLevelingItems<T extends BookmarkableIngredient>(data: T[], selectedItem: T extends BookmarkableExp ? string : undefined) {
-    return this.transactionWithFirestore([this.bookmarks, this.bookmarkCharacters], async() => {
+    return this.transactionWithFirestore([this.bookmarks], async() => {
       const dataToSave: LevelingBookmark[] = data.map((e) => {
         if (isBookmarkableExp(e)) {
           return {
@@ -118,66 +115,30 @@ export class BookmarksProvider extends DbProvider {
       })
 
       // add bookmarks
-      const ids = (await this.bookmarks.bulkAdd(dataToSave, {allKeys: true})) as number[]
-
-      // add bookmark ids to bookmarkCharacters
-      const characterId = data[0].characterId
-      const bookmarkCharacter = await this.bookmarkCharacters.get(characterId)
-      if (bookmarkCharacter) {
-        await this.bookmarkCharacters.update(characterId, {
-          bookmarks: bookmarkCharacter.bookmarks.concat(ids),
-        })
-      } else {
-        await this.bookmarkCharacters.add({
-          characterId,
-          bookmarks: ids,
-        })
-      }
+      await this.bookmarks.bulkAdd(dataToSave, {allKeys: true})
     })
   }
 
   /**
-   * Removes {@link LevelingBookmark}s from the database. Also removes bookmark ids from {@link BookmarkCharacter}.
+   * Removes {@link LevelingBookmark}s from the database.
    *
    * @param ids List of ids to remove
    */
   remove(...ids: number[]) {
-    return this.transactionWithFirestore([this.bookmarks, this.bookmarkCharacters], async() => {
+    return this.transactionWithFirestore([this.bookmarks], async() => {
       await this.bookmarks.bulkDelete(ids)
-
-      // remove bookmark ids from bookmarkCharacters
-      await this.bookmarkCharacters.where("bookmarks").anyOf(ids).modify((bookmarkCharacter) => {
-        bookmarkCharacter.bookmarks = bookmarkCharacter.bookmarks.filter(id => !ids.includes(id))
-      })
-
-      // remove bookmarkCharacters with no bookmarks
-      await this.bookmarkCharacters.filter(e => e.bookmarks.length === 0).delete()
     })
   }
 
   addRelic(data: BookmarkableRelic) {
-    return this.transactionWithFirestore([this.bookmarks, this.bookmarkCharacters], async() => {
+    return this.transactionWithFirestore([this.bookmarks], async() => {
       const dataToSave: RelicBookmark = {
         ...data,
         bookmarkedAt: new Date(),
       }
 
       // add bookmark
-      const id = (await this.bookmarks.add(dataToSave)) as number
-
-      // add bookmark id to bookmarkCharacters
-      const characterId = toCharacterIdWithVariant(data.characterId, data.variant)
-      const bookmarkCharacter = await this.bookmarkCharacters.get(characterId)
-      if (bookmarkCharacter) {
-        await this.bookmarkCharacters.update(characterId, {
-          bookmarks: bookmarkCharacter.bookmarks.concat(id),
-        })
-      } else {
-        await this.bookmarkCharacters.add({
-          characterId,
-          bookmarks: [id],
-        })
-      }
+      await this.bookmarks.add(dataToSave)
     })
   }
 }

--- a/nuxt/types/bookmark/bookmark-character.ts
+++ b/nuxt/types/bookmark/bookmark-character.ts
@@ -1,8 +1,0 @@
-import {CharacterIdWithVariant} from "~/types/strings"
-
-export interface BookmarkCharacter {
-  characterId: CharacterIdWithVariant
-  bookmarks: BookmarkId[]
-}
-
-export type BookmarkId = number

--- a/nuxt/types/bookmark/bookmark.ts
+++ b/nuxt/types/bookmark/bookmark.ts
@@ -1,5 +1,6 @@
 import {Stat} from "~/types/generated/relic-stats.g"
 import {Usage} from "~/types/bookmark/usage"
+import {CharacterIdWithVariant} from "~/types/strings"
 
 export type Bookmark =
   | Bookmark.CharacterMaterial
@@ -17,6 +18,7 @@ export namespace Bookmark {
     id?: number
     type: "character_material"
     bookmarkedAt: Date
+    characterId: CharacterIdWithVariant
     materialId: string
     usage: Usage.Character
     quantity: number
@@ -26,6 +28,7 @@ export namespace Bookmark {
     id?: number
     type: "light_cone_material"
     bookmarkedAt: Date
+    characterId: CharacterIdWithVariant
     materialId: string
     usage: Usage.LightCone
     quantity: number
@@ -35,6 +38,7 @@ export namespace Bookmark {
     id?: number
     type: "character_exp" | "light_cone_exp"
     bookmarkedAt: Date
+    characterId: CharacterIdWithVariant
     usage: Usage.Exp
     exp: number
     selectedItem: string
@@ -44,8 +48,7 @@ export namespace Bookmark {
     id?: number
     type: "relic_set"
     bookmarkedAt: Date
-    characterId: string
-    variant: string | null
+    characterId: CharacterIdWithVariant
     relicSetIds: string[]
     mainStats: Record<string, Stat | null>
     subStats: Stat[]
@@ -55,8 +58,7 @@ export namespace Bookmark {
     id?: number
     type: "relic_piece"
     bookmarkedAt: Date
-    characterId: string
-    variant: string | null
+    characterId: CharacterIdWithVariant
     relicPieceId: string
     mainStat: Stat | null
     subStats: Stat[]

--- a/nuxt/types/bookmark/usage.ts
+++ b/nuxt/types/bookmark/usage.ts
@@ -1,21 +1,16 @@
 import {PurposeType} from "~/types/strings"
-import {Path} from "~/types/generated/characters.g"
 
 export type Usage = Usage.Character | Usage.LightCone | Usage.Exp
 
 export namespace Usage {
   export interface Character {
     type: "character"
-    characterId: string
-    variant: Path | null
     purposeType: PurposeType
     upperLevel: number
   }
 
   export interface LightCone {
     type: "light_cone"
-    characterId: string
-    variant: Path | null
     lightConeId: string
     purposeType: PurposeType & "ascension"
     upperLevel: number
@@ -23,8 +18,6 @@ export namespace Usage {
 
   export interface Exp {
     type: "exp"
-    characterId: string
-    variant: Path | null
     lightConeId: string | null
     purposeType: PurposeType & "ascension"
     upperLevel: number

--- a/nuxt/types/firestore/user-document.ts
+++ b/nuxt/types/firestore/user-document.ts
@@ -1,7 +1,6 @@
 import {Timestamp} from "@firebase/firestore"
 import {Warp} from "#shared/warp"
 import {StoreDefinition} from "pinia"
-import {BookmarkCharacter} from "~/types/bookmark/bookmark-character"
 import {Bookmark} from "~/types/bookmark/bookmark"
 import {useConfigStore} from "~/store/config"
 
@@ -13,7 +12,6 @@ export interface UserDocument {
 }
 
 export interface SyncedUserData {
-  bookmarkCharacters: BookmarkCharacter[]
   bookmarks: Bookmark[]
   warps: Warp[]
 }

--- a/nuxt/utils/migrate.ts
+++ b/nuxt/utils/migrate.ts
@@ -1,7 +1,7 @@
 import {SyncedUserData} from "~/types/firestore/user-document"
 
 export const migrate = (data: { [table: string]: any }, oldVersion: number, newVersion: number): SyncedUserData => {
-  if (oldVersion === 1 && newVersion > 1) {
+  if (oldVersion === 1 && newVersion >= 2) {
     for (const bookmark of data.bookmarks) {
       if ("usage" in bookmark) {
         bookmark.characterId = toCharacterIdWithVariant(bookmark.usage.characterId, bookmark.usage.variant)
@@ -12,6 +12,8 @@ export const migrate = (data: { [table: string]: any }, oldVersion: number, newV
         delete bookmark.variant
       }
     }
+
+    delete data.bookmarkCharacters
     oldVersion++
   }
 

--- a/nuxt/utils/migrate.ts
+++ b/nuxt/utils/migrate.ts
@@ -1,7 +1,19 @@
-export const migrate = (data: any, oldVersion: number, newVersion: number) => {
+import {SyncedUserData} from "~/types/firestore/user-document"
+
+export const migrate = (data: { [table: string]: any }, oldVersion: number, newVersion: number): SyncedUserData => {
   if (oldVersion === 1 && newVersion > 1) {
+    for (const bookmark of data.bookmarks) {
+      if ("usage" in bookmark) {
+        bookmark.characterId = toCharacterIdWithVariant(bookmark.usage.characterId, bookmark.usage.variant)
+        delete bookmark.usage.characterId
+        delete bookmark.usage.variant
+      } else {
+        bookmark.characterId = toCharacterIdWithVariant(bookmark.characterId, bookmark.variant)
+        delete bookmark.variant
+      }
+    }
     oldVersion++
   }
 
-  return data
+  return data as SyncedUserData
 }


### PR DESCRIPTION
## 概要

元々`bookmarks`テーブル内にcharacterIdを保存しない予定だったので`bookmarkedCharacters`テーブルが存在しているが、結局保存したので必要性がなくなった。

`bookmarkedCharacters`テーブルを削除し、ブックマーク一覧表示では`computed`でキャラ一覧を取得する方法に変更。

また、`characterId`を保存している場所がバラバラだったのでトップレベルで統一し、`variant`も含めた`CharacterIdWithVariant`の形式で保存。