### PR TITLE
Revert "chore: TypeScript v5.1.6に更新"

### DIFF
--- a/nuxt/package.json
+++ b/nuxt/package.json
@@ -23,7 +23,7 @@
     "eslint-plugin-vue": "^9.15.1",
     "nuxt": "^3.6.5",
     "sass": "^1.64.1",
-    "typescript": "^5.1.6"
+    "typescript": "^4"
   },
   "dependencies": {
     "@mdi/font": "^7.2.96",

--- a/nuxt/yarn.lock
+++ b/nuxt/yarn.lock
@@ -10321,7 +10321,7 @@ __metadata:
     rxjs: ^7.8.1
     sass: ^1.64.1
     sitemap: ^7.1.1
-    typescript: ^5.1.6
+    typescript: ^4
     ua-parser-js: ^1.0.35
     vuetify: ^3.3.10
   languageName: unknown
@@ -11339,23 +11339,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.1.6":
-  version: 5.1.6
-  resolution: "typescript@npm:5.1.6"
+"typescript@npm:^4":
+  version: 4.9.5
+  resolution: "typescript@npm:4.9.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: b2f2c35096035fe1f5facd1e38922ccb8558996331405eb00a5111cc948b2e733163cc22fab5db46992aba7dd520fff637f2c1df4996ff0e134e77d3249a7350
+  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.1.6#~builtin<compat/typescript>":
-  version: 5.1.6
-  resolution: "typescript@patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"
+"typescript@patch:typescript@^4#~builtin<compat/typescript>":
+  version: 4.9.5
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: f53bfe97f7c8b2b6d23cf572750d4e7d1e0c5fff1c36d859d0ec84556a827b8785077bc27676bf7e71fae538e517c3ecc0f37e7f593be913d884805d931bc8be
+  checksum: 1f8f3b6aaea19f0f67cba79057674ba580438a7db55057eb89cc06950483c5d632115c14077f6663ea76fd09fce3c190e6414bb98582ec80aa5a4eaf345d5b68
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts chika3742/hsr-material#131

まだ不安定でおかしい部分が多いので、当分は4のまま使用する。