### PR TITLE
modify: Release Notesのデータを上下反転

### DIFF
--- a/nuxt/assets/data/release-notes.yaml
+++ b/nuxt/assets/data/release-notes.yaml
@@ -1,15 +1,41 @@
-# コピー用改行
+- date: 2023/07/14
+  funcVersion: 1.0.0-beta.1
+  dataVersion: 1.0.0
+  isMajor: true
+  content: |
+    ### 初回ベータリリース版
 
-- date: 2023/07/27
-  funcVersion: 1.0.0-beta.5
-  dataVersion: 1.2.0
+- date: 2023/07/14
+  funcVersion: 1.0.0-beta.2
+  dataVersion: 1.0.0
   isMajor: false
   content: |
-    ### 機能追加
+    ### 修正
     
-    - PWAに対応しました。ホーム画面から単独のアプリのように起動できるようになります。
-      - iOS版Safariにおいては、共有ボタン→「ホーム画面に追加」で追加できます。
-    - 初回アクセス時にスクリプトと画像をキャッシュするようになりました。画面遷移の際のロードが大幅に短縮されます。
+    * 製品版扱いの動作にならない問題の修正
+
+- date: 2023/07/15
+  funcVersion: 1.0.0-beta.3
+  dataVersion: 1.0.0
+  isMajor: false
+  content: |
+    ### 調整
+    
+    * 更新履歴ページのレイアウト調整と凡例表示の改善
+    * ベータ版バナーの削除
+    
+    ### 修正
+    
+    * 遺物ブックマーク時、「開拓者(壊滅)」と「開拓者(存護)」が区別されない不具合の修正
+
+- date: 2023/07/15
+  funcVersion: 1.0.0-beta.4
+  dataVersion: 1.0.0
+  isMajor: false
+  content: |
+    ### 追加
+    
+    * キャラの所持・未所持で絞り込む機能の追加
 
 - date: 2023/07/22
   funcVersion: 1.0.0-beta.4
@@ -33,50 +59,14 @@
     * 素材「天人の残穢」「無窮なる仮身の遺恨」追加
     * 遺物セット「宝命長存の蒔者」「仮想空間を漫遊するメッセンジャー」 「星々の競技場」「折れた竜骨」追加
 
-- date: 2023/07/22
-  funcVersion: 1.0.0-beta.4
-  dataVersion: 1.0.1
+- date: 2023/07/27
+  funcVersion: 1.0.0-beta.5
+  dataVersion: 1.2.0
   isMajor: false
   content: |
-    ### データ追加
+    ### 機能追加
     
-    * ☆5キャラのEXP、☆3光円錐のEXPの数値を追加
+    - PWAに対応しました。ホーム画面から単独のアプリのように起動できるようになります。
+      - iOS版Safariにおいては、共有ボタン→「ホーム画面に追加」で追加できます。
+    - 初回アクセス時にスクリプトと画像をキャッシュするようになりました。画面遷移の際のロードが大幅に短縮されます。
 
-- date: 2023/07/15
-  funcVersion: 1.0.0-beta.4
-  dataVersion: 1.0.0
-  isMajor: false
-  content: |
-    ### 追加
-    
-    * キャラの所持・未所持で絞り込む機能の追加
-
-- date: 2023/07/15
-  funcVersion: 1.0.0-beta.3
-  dataVersion: 1.0.0
-  isMajor: false
-  content: |
-    ### 調整
-    
-    * 更新履歴ページのレイアウト調整と凡例表示の改善
-    * ベータ版バナーの削除
-    
-    ### 修正
-    
-    * 遺物ブックマーク時、「開拓者(壊滅)」と「開拓者(存護)」が区別されない不具合の修正
-
-- date: 2023/07/14
-  funcVersion: 1.0.0-beta.2
-  dataVersion: 1.0.0
-  isMajor: false
-  content: |
-    ### 修正
-    
-    * 製品版扱いの動作にならない問題の修正
-
-- date: 2023/07/14
-  funcVersion: 1.0.0-beta.1
-  dataVersion: 1.0.0
-  isMajor: true
-  content: |
-    ### 初回ベータリリース版

--- a/nuxt/pages/release-notes.vue
+++ b/nuxt/pages/release-notes.vue
@@ -12,7 +12,14 @@
         >
           <template #opposite>
             <div v-show="!$vuetify.display.smAndDown" class="changelog-title">
-              <span class="font-weight-bold">{{ getVersionText(item) }}</span>
+              <span
+                v-if="item.funcVersion !== reversedReleaseNotes[i + 1]?.funcVersion"
+                class="font-weight-bold"
+              >v{{ item.funcVersion }}</span>
+              <span
+                v-if="item.dataVersion !== reversedReleaseNotes[i + 1]?.dataVersion"
+                class="font-weight-bold"
+              >D{{ item.dataVersion }}</span>
               <span style="font-size: 0.8em">{{ item.date }}</span>
             </div>
           </template>
@@ -60,6 +67,7 @@
 
 <script lang="ts" setup>
 import releaseNotes from "~/assets/data/release-notes.yaml"
+import {ReleaseNote} from "~/types/generated/release-notes.g"
 
 definePageMeta({
   title: "releaseNotes",

--- a/nuxt/pages/release-notes.vue
+++ b/nuxt/pages/release-notes.vue
@@ -5,9 +5,9 @@
 
       <v-timeline align="start" side="end">
         <v-timeline-item
-          v-for="(item, i) in releaseNotes"
+          v-for="(item, i) in reversedReleaseNotes"
           :key="i"
-          :dot-color="item.funcVersion !== releaseNotes[i + 1]?.funcVersion ? '#ffc046' : '#40fff8'"
+          :dot-color="item.funcVersion !== reversedReleaseNotes[i + 1]?.funcVersion ? '#ffc046' : '#40fff8'"
           :size="item.isMajor ? 'default' : 'small'"
         >
           <template #opposite>
@@ -68,6 +68,8 @@ definePageMeta({
 const {$marked} = useNuxtApp()
 
 const marked = $marked({})
+
+const reversedReleaseNotes = [...releaseNotes].reverse() as ReleaseNote[]
 </script>
 
 <style lang="sass">


### PR DESCRIPTION
バージョン管理の際に正しくdiffが認識されない不都合があるため、リリースノートのyamlファイルを反転し、下が時系列的に新しいものになるように。

さらに、一覧でのバージョンの表示形式を微調整。