### PR TITLE
fix: nitroのpresetをcloudflare-pages-staticに変更

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -66,7 +66,7 @@ export default defineNuxtConfig({
     ],
   },
   nitro: {
-    preset: "node-server",
+    preset: "cloudflare-pages-static",
     hooks: {
       "prerender:route"(route) {
         routes.push(route.route)


### PR DESCRIPTION
Nuxt(nitro)の更新により、nitroのpresetの内容が変更された模様。クロールして静的ページが生成されなくなったため、適切である`cloudflare-pages-static`を設定。