### PR TITLE
feat: ドロワーにKo-fiリンク追加、フッターにフィードバックメニュー追加

### DIFF
--- a/nuxt/components/app/drawer.vue
+++ b/nuxt/components/app/drawer.vue
@@ -75,6 +75,12 @@ const drawerItems: (DrawerItem | Divider)[] = [
     icon: "mdi-information",
     to: "/about",
   },
+  {
+    icon: "mdi-coffee",
+    title: "kofi",
+    href: "https://ko-fi.com/chika3742",
+    target: "_blank",
+  },
 ]
 </script>
 

--- a/nuxt/components/app/footer.vue
+++ b/nuxt/components/app/footer.vue
@@ -5,8 +5,22 @@
         <v-btn icon="mdi-twitter" href="https://twitter.com/gms_material" target="_blank" variant="text" density="comfortable" />
         <v-btn icon="mdi-github" href="https://github.com/chika3742/hsr-material" target="_blank" variant="text" density="comfortable" />
         <client-only>
-          <v-btn :href="feedbackUrl" variant="text" density="comfortable" target="_blank">
+          <v-btn density="comfortable" variant="text">
             {{ $t('footer.feedback') }}
+
+            <v-menu activator="parent">
+              <v-list>
+                <v-list-item
+                  v-for="(item, i) in feedbackMenuItems"
+                  :key="i"
+                  :href="item.url"
+                  :subtitle="item.desc"
+                  :title="item.title"
+                  lines="two"
+                  target="_blank"
+                />
+              </v-list>
+            </v-menu>
           </v-btn>
         </client-only>
         <v-btn :to="localePath('/release-notes')" color="primary" variant="text" density="comfortable">
@@ -86,6 +100,7 @@ import {ThemeSetting} from "~/types/strings"
 
 const config = useConfigStore()
 const vTheme = useTheme()
+const i18n = useI18n()
 
 const availableLocales: {code: string, name: string}[] = [
   {code: "en", name: "English"},
@@ -103,6 +118,26 @@ const feedbackUrl = computed(() => {
   const ua = new UAParser(navigator.userAgent)
   const browser = ua.getBrowser()
   return `https://github.com/chika3742/hsr-material/issues/new/choose?browser=${browser.name} ${browser.version}&app-version=${getCurrentVersionText()}`
+})
+
+const feedbackMenuItems = computed(() => {
+  return [
+    {
+      title: tx(i18n, "footer.feedbackMenuItems.comment"),
+      desc: tx(i18n, "footer.feedbackMenuItems.commentDesc"),
+      url: "https://www.chikach.net/hsr-material-fb",
+    },
+    {
+      title: tx(i18n, "footer.feedbackMenuItems.hoyolab"),
+      desc: tx(i18n, "footer.feedbackMenuItems.hoyolabDesc"),
+      url: "https://www.hoyolab.com/article/18406761",
+    },
+    {
+      title: tx(i18n, "footer.feedbackMenuItems.github"),
+      desc: tx(i18n, "footer.feedbackMenuItems.githubDesc"),
+      url: feedbackUrl.value,
+    },
+  ]
 })
 
 </script>

--- a/nuxt/locales/en.yaml
+++ b/nuxt/locales/en.yaml
@@ -63,6 +63,9 @@ pageTitles:
   privacy: Privacy Policy
   about: About This App
 
+navDrawer:
+  kofi: Buy me a coffee
+
 footer:
   feedback: Submit Issue
   theme: Theme

--- a/nuxt/locales/en.yaml
+++ b/nuxt/locales/en.yaml
@@ -67,7 +67,7 @@ navDrawer:
   kofi: Buy me a coffee
 
 footer:
-  feedback: Submit Issue
+  feedback: Feedback
   theme: Theme
   disclaimer: |
     This app is unofficial. All images and data are owned by miHoYo/COGNOSPHERE.

--- a/nuxt/locales/ja.yaml
+++ b/nuxt/locales/ja.yaml
@@ -63,6 +63,9 @@ pageTitles:
   privacy: プライバシーポリシー
   about: このアプリについて
 
+navDrawer:
+  kofi: コーヒーを奢る
+
 footer:
   feedback: Issueを立てる
   theme: テーマ

--- a/nuxt/locales/ja.yaml
+++ b/nuxt/locales/ja.yaml
@@ -67,7 +67,14 @@ navDrawer:
   kofi: コーヒーを奢る
 
 footer:
-  feedback: Issueを立てる
+  feedback: フィードバック
+  feedbackMenuItems:
+    comment: コメントページ
+    commentDesc: アカウント作成不要で送信できます。
+    hoyolab: HoYoLAB
+    hoyolabDesc: 記事へのコメントでフィードバックできます。
+    github: GitHub
+    githubDesc: 知識のある方は、直接Issueを立てることもできます。
   theme: テーマ
   disclaimer: このアプリは非公式です。画像・データの著作権はmiHoYo/COGNOSPHEREに帰属します。
   themeOptions:


### PR DESCRIPTION
フッターのフィードバックメニューは、フィードバックの送信方法を3通り用意し、整理。

英語翻訳は追加しない。