### PR TITLE
feat: キャラページから光円錐リストページへのリンク追加 (closes #164)

### DIFF
--- a/nuxt/components/grouped-list.vue
+++ b/nuxt/components/grouped-list.vue
@@ -7,6 +7,7 @@ const props = withDefaults(defineProps<{
   categoryI18nKey: string
   itemI18nKey: string
   linkBasePath: string
+  preserveQuery?: boolean
   hasSubtitle?: boolean
 }>(), {
   hasSubtitle: false,
@@ -48,6 +49,7 @@ const opened = computed({
         :item="item"
         :item-i18n-key="itemI18nKey"
         :link-base-path="linkBasePath"
+        :preserve-query="preserveQuery"
         :lines="hasSubtitle ? 'two' : 'one'"
       >
         <template #subtitle>

--- a/nuxt/components/item-list-item.vue
+++ b/nuxt/components/item-list-item.vue
@@ -2,6 +2,7 @@
 withDefaults(defineProps<{
   item: Record<string, unknown> & { id: string, rarity: number }
   linkBasePath: string
+  preserveQuery?: boolean
   itemI18nKey: string
   imageFunc: (id: string) => string
   lines?: "one" | "two"
@@ -11,7 +12,13 @@ withDefaults(defineProps<{
 </script>
 
 <template>
-  <v-list-item :lines="lines" :to="localePath(`${linkBasePath}/${item.id}`)">
+  <v-list-item
+    :lines="lines"
+    :to="localePath({
+      path: `${linkBasePath}/${item.id}`,
+      query: preserveQuery ? $route.query : {},
+    })"
+  >
     <template #prepend>
       <v-img :src="imageFunc(item.id)" aspect-ratio="1" class="mr-2" width="45px" />
     </template>

--- a/nuxt/locales/en.yaml
+++ b/nuxt/locales/en.yaml
@@ -96,6 +96,7 @@ charactersPage:
 
 characterDetailsPage:
   iHave: I have this character.
+  bookmarkLightCone: Bookmark Light Cone
   ascension: Ascension / Character Level Up Materials
   skills: Skill Leveling Materials
 

--- a/nuxt/locales/ja.yaml
+++ b/nuxt/locales/ja.yaml
@@ -101,6 +101,7 @@ charactersPage:
 
 characterDetailsPage:
   iHave: 所持
+  bookmarkLightCone: 光円錐をブックマーク
   ascension: キャラLvアップ/昇格素材
   skills: スキルLvアップ素材
 

--- a/nuxt/pages/characters/[characterId].vue
+++ b/nuxt/pages/characters/[characterId].vue
@@ -69,15 +69,20 @@ onActivated(() => {
       </div>
 
       <!-- Is owned checkbox -->
-      <v-checkbox-btn
+      <v-checkbox
         v-if="character.id !== 'trailblazer'"
         v-model="config.ownedCharacters"
+        :label="tx('characterDetailsPage.iHave')"
         :value="character.id"
-      >
-        <template #label>
-          <span class="text-no-wrap">{{ tx('characterDetailsPage.iHave') }}</span>
-        </template>
-      </v-checkbox-btn>
+        class="flex-0-0"
+        hide-details
+      />
+
+      <v-btn
+        :text="tx('characterDetailsPage.bookmarkLightCone')"
+        :to="localePath({path: '/light-cones', query: {character: character.id}})"
+        prepend-icon="mdi-cone"
+      />
     </v-row>
 
     <client-only>

--- a/nuxt/pages/light-cones/index.vue
+++ b/nuxt/pages/light-cones/index.vue
@@ -2,10 +2,13 @@
 import GroupedList from "~/components/grouped-list.vue"
 import lightCones from "~/assets/data/light-cones.yaml"
 import EmphasizedText from "~/components/emphasized-text.vue"
+import characters from "~/assets/data/characters.yaml"
 
 definePageMeta({
   title: "lightCones",
 })
+
+const route = useRoute()
 
 const filteringRarity = ref<number[]>([])
 const expanded = ref<number[]>([])
@@ -17,6 +20,15 @@ const items = computed(() => {
 
 const spiltByRarity = splitByField(lightCones, "rarity")
 const spiltByPath = splitByField(lightCones, "path")
+
+onActivated(() => {
+  if (route.query.character) {
+    const queryCharacter = characters.find(e => e.id === route.query.character)
+    if (typeof queryCharacter !== "undefined") {
+      expanded.value = [spiltByPath.findIndex(e => e[0].path === queryCharacter.path)]
+    }
+  }
+})
 </script>
 
 <template>
@@ -73,6 +85,7 @@ const spiltByPath = splitByField(lightCones, "path")
       item-i18n-key="lightConeNames"
       link-base-path="/light-cones"
       :has-subtitle="showSkillDescriptions"
+      preserve-query
     >
       <template #subtitle="{itemId}">
         <v-list-item-subtitle v-if="showSkillDescriptions" class="mt-1">


### PR DESCRIPTION
キャラページから光円錐リストページへ、最初からそのキャラが選択された状態で飛べるように。
運命のグループも適切なものが最初から展開されるように。