### PR TITLE
fix: スライダーが意図しない動作をする問題の修正

### DIFF
--- a/nuxt/components/single-slider-panel.vue
+++ b/nuxt/components/single-slider-panel.vue
@@ -59,18 +59,18 @@ const setInitialRangeBasedOnBookmarks = async() => {
     "ascension",
   )
 
-  if (bookmarks.length === 0) {
-    return
+  if (bookmarks.length !== 0) {
+    const min = bookmarks.reduce((a, b) => Math.min(a, b.usage.upperLevel), bookmarks[0].usage.upperLevel)
+    const max = bookmarks.reduce((a, b) => Math.max(a, b.usage.upperLevel), bookmarks[0].usage.upperLevel)
+
+    range.value = [sliderTicks.value[sliderTicks.value.indexOf(min) - 1], max]
+  } else {
+    range.value = [sliderTicks.value[0], sliderTicks.value.slice(-1)[0]]
   }
-
-  const min = bookmarks.reduce((a, b) => Math.min(a, b.usage.upperLevel), bookmarks[0].usage.upperLevel)
-  const max = bookmarks.reduce((a, b) => Math.max(a, b.usage.upperLevel), bookmarks[0].usage.upperLevel)
-
-  range.value = [sliderTicks.value[sliderTicks.value.indexOf(min) - 1], max]
 }
-onMounted(() => {
+watch(toRefs(props).characterId, () => {
   setInitialRangeBasedOnBookmarks()
-})
+}, {immediate: true})
 
 const ingredientsWithinSelectedLevelRange = computed<LevelIngredients[]>(() => {
   return levelIngredients.filter(e => range.value[0] < e.level && e.level <= range.value[1])

--- a/nuxt/libs/db/bookmarks-provider.ts
+++ b/nuxt/libs/db/bookmarks-provider.ts
@@ -80,16 +80,19 @@ export class BookmarksProvider extends DbProvider {
       .and((e) => {
         const item = e as BookmarkableIngredient
 
-        switch (item.type) {
-          case "character_exp":
-          case "character_material":
-            // filtered by characterId, variant, and purposeType
-            return item.usage.purposeType === purposeType
-          case "light_cone_exp":
-          case "light_cone_material":
-            // filtered by characterId, variant, lightConeId, and purposeType
-            return item.usage.lightConeId === lightConeId && item.usage.purposeType === purposeType
+        if (
+          typeof lightConeId !== "undefined" &&
+          (item.type === "light_cone_exp" || item.type === "light_cone_material")
+        ) {
+          return item.usage.lightConeId === lightConeId && item.usage.purposeType === purposeType
+        } else if (
+          typeof lightConeId === "undefined" &&
+          (item.type === "character_exp" || item.type === "character_material")
+        ) {
+          return item.usage.purposeType === purposeType
         }
+
+        return false
       }).toArray() as Promise<LevelingBookmark[]>
   }
 


### PR DESCRIPTION
- キャラにブックマークが存在する際、光円錐ページで同キャラを選択した際にスライダーが動いてしまうバグを修正。`getByPurpose` メソッドにて、`lightConeId` が `undefined` であるかどうかの条件分岐が行われていなかったことが原因。
- 光円錐ページのキャラ選択を切り替えてもスライダーが動かない問題の修正。