### PR TITLE
fix: スキルのチェックボックスの初期値が不正

### DIFF
--- a/nuxt/components/skill-sliders-panel.vue
+++ b/nuxt/components/skill-sliders-panel.vue
@@ -49,30 +49,27 @@ const ranges = ref(sliders.map((e) => {
 }))
 const checkedList = ref(sliders.map(() => true))
 const setInitialRangeBasedOnBookmarks = async() => {
-  {
-    let index = 0
-    for (const slider of sliders) {
-      const bookmarks = await db.bookmarks.getByPurpose(
-        props.characterId,
-        props.variant,
-        undefined,
-        slider.type,
-      )
+  for (let index = 0; index < sliders.length; index++) {
+    const slider = sliders[index]
 
-      if (bookmarks.length === 0) {
-        checkedList.value[index] = false
-        continue
-      }
+    const bookmarks = await db.bookmarks.getByPurpose(
+      props.characterId,
+      props.variant,
+      undefined,
+      slider.type,
+    )
 
-      const min = bookmarks.reduce((a, b) => Math.min(a, b.usage.upperLevel), bookmarks[0].usage.upperLevel)
-      const max = bookmarks.reduce((a, b) => Math.max(a, b.usage.upperLevel), bookmarks[0].usage.upperLevel)
-
-      const sliderTicks = levelIngredientsToSliderTicks(slider.levelIngredients)
-
-      ranges.value[index] = [sliderTicks[sliderTicks.indexOf(min) - 1], max]
-
-      index++
+    if (bookmarks.length === 0) {
+      checkedList.value[index] = false
+      continue
     }
+
+    const min = bookmarks.reduce((a, b) => Math.min(a, b.usage.upperLevel), bookmarks[0].usage.upperLevel)
+    const max = bookmarks.reduce((a, b) => Math.max(a, b.usage.upperLevel), bookmarks[0].usage.upperLevel)
+
+    const sliderTicks = levelIngredientsToSliderTicks(slider.levelIngredients)
+
+    ranges.value[index] = [sliderTicks[sliderTicks.indexOf(min) - 1], max]
   }
 
   if (checkedList.value.every(e => !e)) {


### PR DESCRIPTION
何もブックマークしていない際に、通常攻撃だけチェックボックスが外れている場合があった。
bookmarksのlengthが0でcontinueした際に、indexがインクリメントされていなかったのが原因。