### PR TITLE
feat: 画面セーフエリア対応

### DIFF
--- a/nuxt/app.vue
+++ b/nuxt/app.vue
@@ -30,7 +30,7 @@
         </div>
 
         <div class="d-flex flex-column h-100">
-          <v-container>
+          <v-container v-safe-area="{left: 16, right: 16, top: false, bottom: false}">
             <NuxtPage :keepalive="{max: 5, exclude: ['v-tooltip']}" :page-key="$router.currentRoute.value.path" />
           </v-container>
 

--- a/nuxt/components/app/drawer.vue
+++ b/nuxt/components/app/drawer.vue
@@ -86,7 +86,7 @@ const drawerItems: (DrawerItem | Divider)[] = [
 
 <template>
   <v-navigation-drawer v-model="isOpen" expand-on-hover>
-    <v-list nav>
+    <v-list v-safe-area="{left: 8, top: false, right: false, bottom: false}" nav>
       <template v-for="(item, i) in drawerItems">
         <v-list-item
           v-if="item !== '---'"
@@ -104,7 +104,3 @@ const drawerItems: (DrawerItem | Divider)[] = [
     </v-list>
   </v-navigation-drawer>
 </template>
-
-<style scoped>
-
-</style>

--- a/nuxt/components/app/footer.vue
+++ b/nuxt/components/app/footer.vue
@@ -1,6 +1,6 @@
 <template>
   <v-footer elevation="4" color="footer" class="flex-grow-0">
-    <div class="d-flex flex-column w-100">
+    <div v-safe-area="{top: false}" class="d-flex flex-column w-100">
       <div class="d-flex align-center justify-end flex-wrap mb-4">
         <v-btn icon="mdi-twitter" href="https://twitter.com/gms_material" target="_blank" variant="text" density="comfortable" />
         <v-btn icon="mdi-github" href="https://github.com/chika3742/hsr-material" target="_blank" variant="text" density="comfortable" />

--- a/nuxt/components/relic/bookmark-dialog.client.vue
+++ b/nuxt/components/relic/bookmark-dialog.client.vue
@@ -190,12 +190,15 @@ const getCheckBoxDisabled = (stat: Stat): boolean => {
 <template>
   <v-dialog
     :model-value="modelValue"
-    max-width="600px"
+    :max-width="!$vuetify.display.xs ? '600px' : ''"
     :fullscreen="$vuetify.display.xs"
     scrollable
     @update:model-value="$emit('update:modelValue', $event)"
   >
-    <v-card :title="relicSets ? tx('relicDetailsPage.bookmarkRelicSet') : tx('relicDetailsPage.bookmarkRelicPiece')">
+    <v-card
+      v-safe-area
+      :title="relicSets ? tx('relicDetailsPage.bookmarkRelicSet') : tx('relicDetailsPage.bookmarkRelicPiece')"
+    >
       <template #text>
         <div>
           <!-- Relic set view -->

--- a/nuxt/components/search-dialog.vue
+++ b/nuxt/components/search-dialog.vue
@@ -118,7 +118,7 @@ const urlToRouteLocation = (url: string): RawLocation => {
     height="100%"
   >
     <v-card height="100%">
-      <div class="h-100 d-flex flex-column">
+      <div v-safe-area="{bottom: false}" class="h-100 d-flex flex-column">
         <v-row class="flex-grow-0 mx-4 mt-4" no-gutters style="gap: 8px">
           <v-text-field
             ref="textField"
@@ -165,6 +165,7 @@ const urlToRouteLocation = (url: string): RawLocation => {
             :to="localePath(urlToRouteLocation(item.url))"
             @click="clearQuery(); closeDialog()"
           />
+          <div style="height: env(safe-area-inset-bottom)" />
         </v-list>
       </div>
     </v-card>

--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -34,6 +34,12 @@ export default defineNuxtConfig({
           href: "/manifest.webmanifest",
         },
       ],
+      meta: [
+        {
+          name: "viewport",
+          content: "viewport-fit=cover, width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no",
+        },
+      ],
     },
   },
   build: {

--- a/nuxt/plugins/v-safe-area.ts
+++ b/nuxt/plugins/v-safe-area.ts
@@ -1,0 +1,31 @@
+import {DirectiveBinding} from "vue"
+
+export default defineNuxtPlugin(({vueApp}) => {
+  interface SafeAreaOptions {
+    /**
+     * You can specify the minimum padding value by passing a number.
+     * @default true
+     */
+    top?: boolean | number,
+    right?: boolean | number,
+    bottom?: boolean | number,
+    left?: boolean | number,
+  }
+
+  vueApp.directive("safe-area", {
+    mounted(el, binding: DirectiveBinding<SafeAreaOptions>) {
+      if (binding.value?.top !== false) {
+        el.style.paddingTop = `max(env(safe-area-inset-top), ${typeof binding.value?.top === "number" ? binding.value?.top : 0}px)`
+      }
+      if (binding.value?.right !== false) {
+        el.style.paddingRight = `max(env(safe-area-inset-right), ${typeof binding.value?.right === "number" ? binding.value?.right : 0}px)`
+      }
+      if (binding.value?.bottom !== false) {
+        el.style.paddingBottom = `max(env(safe-area-inset-bottom), ${typeof binding.value?.bottom === "number" ? binding.value?.bottom : 0}px)`
+      }
+      if (binding.value?.left !== false) {
+        el.style.paddingLeft = `max(env(safe-area-inset-left), ${typeof binding.value?.left === "number" ? binding.value?.left : 0}px)`
+      }
+    },
+  })
+})


### PR DESCRIPTION
## 概要

`v-safe-area`ディレクティブを作成し、セーフエリア分のパディングを入れたい要素に以下のように`v-safe-area`と記述することで自動的にパディングが追加される。

```Vue
<div v-safe-area />
```

paddingの値は上書きされるため、以下のようにpaddingの最小値を指定することも可能 (単位: px)。

```Vue
<div v-safe-area="{bottom: 16}" />
```

セーフエリア分のパディングを入れない方向には、`false`を指定することで無効化できる。

```Vue
<div v-safe-area="{top: false}" />
```

これを用いて、以下のコンポーネントにセーフエリア対応を施した。

- app.vue内の`v-container`
- ナビゲーションドロワー
- フッター
- `RelicBookmarkDialog`コンポーネント
- `SearchDialog`コンポーネント