### PR TITLE
refactor: ブックマークリストのクエリ方法を改善

### DIFF
--- a/nuxt/components/bookmark/details-dialog.vue
+++ b/nuxt/components/bookmark/details-dialog.vue
@@ -1,14 +1,13 @@
 <script lang="ts" setup>
 import _ from "lodash"
 import {PurposeType} from "~/types/strings"
-import {Bookmark, LevelingBookmark} from "~/types/bookmark/bookmark"
+import {LevelingBookmark} from "~/types/bookmark/bookmark"
 import {materialSortFunc} from "~/utils/merge-items"
 import {db} from "~/libs/db/providers"
 
 interface Props {
   modelValue: boolean
   items: LevelingBookmark[]
-  bookmarks: Bookmark[]
   showFarmingCount?: boolean
 }
 

--- a/nuxt/components/bookmark/list.vue
+++ b/nuxt/components/bookmark/list.vue
@@ -10,8 +10,11 @@ import {CharacterIdWithVariant} from "~/types/strings"
 
 const config = useConfigStore()
 
-const _bookmarkedCharacterIds = useObservable(from(liveQuery(() => {
-  return _db.bookmarks.orderBy("characterId").uniqueKeys() as Promise<CharacterIdWithVariant[]>
+const _bookmarkedCharacterIds = useObservable(from(liveQuery(async() => {
+  if (await _db.bookmarks.count() === 0) {
+    return []
+  }
+  return await _db.bookmarks.orderBy("characterId").uniqueKeys() as CharacterIdWithVariant[]
 })), {
   initialValue: [] as string[],
 })

--- a/nuxt/dexie/db.ts
+++ b/nuxt/dexie/db.ts
@@ -21,13 +21,13 @@ export class MySubClassedDexie extends Dexie {
       bookmarkCharacters: null,
       bookmarks: "++id, characterId",
     }).upgrade(async() => {
-      await this.import(migrate(await this.dump(), 1, 2))
+      await this.migrateIdb(2)
     })
 
     this.version(3).stores({
       bookmarks: "++id, characterId, hash",
     }).upgrade(async() => {
-      await this.import(migrate(await this.dump(), 2, 3))
+      await this.migrateIdb(3)
     })
   }
 
@@ -46,6 +46,10 @@ export class MySubClassedDexie extends Dexie {
         return await table.bulkAdd(tableData as unknown[])
       })
     })
+  }
+
+  async migrateIdb(version: number) {
+    return await this.import(migrate(await this.dump(), version - 1, version))
   }
 
   importRemote(data: UserDocument) {

--- a/nuxt/libs/db/bookmarks-provider.ts
+++ b/nuxt/libs/db/bookmarks-provider.ts
@@ -1,7 +1,7 @@
 import {Table} from "dexie"
 import hash from "object-hash"
 import {Bookmark, LevelingBookmark, RelicBookmark} from "~/types/bookmark/bookmark"
-import {PurposeType} from "~/types/strings"
+import {CharacterIdWithVariant, PurposeType} from "~/types/strings"
 import {_db} from "~/dexie/db"
 import {DbProvider} from "~/libs/db/db-provider"
 import {
@@ -78,6 +78,10 @@ export class BookmarksProvider extends DbProvider {
 
   getLevelingItemByHash(hash: string) {
     return this.bookmarks.where("hash").equals(hash).toArray() as Promise<LevelingBookmark[]>
+  }
+
+  getByCharacter(character: CharacterIdWithVariant) {
+    return this.bookmarks.where("characterId").equals(character).toArray() as Promise<Bookmark[]>
   }
 
   getByPurpose(characterId: string, variant: string | null, lightConeId: string | undefined, purposeType: PurposeType) {


### PR DESCRIPTION
refactor: ブックマークリストのクエリ方法を改善

- ルートとなる親ページで全ブックマーク内容を取得し、JavaScriptで仕分けて各キャラカードに分配

↓

- ルートとなる親ページでキャラクターIDのユニークなキーのみをクエリ
- 各キャラカードでそのキャラごとのブックマーク内容をliveQueryで取得