### PR TITLE
fix: adopt forward-compatible approach to `builder:watch`

### DIFF
--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -1,3 +1,4 @@
+import { relative, resolve } from 'node:path'
 import {execSync} from "child_process"
 import {Readable} from "stream"
 import fs from "fs"
@@ -122,6 +123,7 @@ export default defineNuxtConfig({
       generateLocType()
     },
     async "builder:watch"(_, _path) {
+      _path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, _path))
       if (_path.startsWith("schemas/")) {
         await generateSchemas()
       }


### PR DESCRIPTION
We are planning to move to [emitting absolute paths in `builder:watch` in Nuxt v4](https://github.com/nuxt/nuxt/issues/25339). You can see a little more about the history in the PR linked in that issue.

This PR is an attempt to use a forward/backward compatible approach, namely resolving the path to ensure it's absolute, then making it relative so your existing code will continue to work.

This should be safe to merge as is, but do let me know if you have any concerns about this approach.

