### PR TITLE
feat: 跳躍天井カウンター履歴エクスポート機能を追加

### DIFF
--- a/packages/nuxt/i18n/locales/en.yaml
+++ b/packages/nuxt/i18n/locales/en.yaml
@@ -208,6 +208,7 @@ warpsPage:
     1: Standard Warp
   urlInput: URL Input
   get: "Get Warps"
+  export: "Export History"
   clear: "Clear Warps"
   progress: "Fetched {gachaCount} warp(s) ({gachaTypeCount}/{gachaTypeTotal})"
   preparing: Preparing...

--- a/packages/nuxt/i18n/locales/ja.yaml
+++ b/packages/nuxt/i18n/locales/ja.yaml
@@ -204,6 +204,7 @@ warpsPage:
     1: 通常跳躍
   urlInput: URL入力
   get: "跳躍を取得"
+  export: "履歴をエクスポート"
   clear: "跳躍をクリア"
   progress: "取得済みの跳躍数: {gachaCount} ({gachaTypeCount}/{gachaTypeTotal})"
   preparing: 履歴取得の準備をしています...

--- a/packages/nuxt/pages/warps.vue
+++ b/packages/nuxt/pages/warps.vue
@@ -52,6 +52,13 @@
           style="gap: 16px"
         >
           <v-spacer />
+          <v-btn
+            :disabled="warps.length === 0"
+            prepend-icon="mdi-download"
+            @click="exportWarps"
+          >
+            {{ $t("warpsPage.export") }}
+          </v-btn>
           <v-btn @click="clearWarps">
             {{ $t("warpsPage.clear") }}
           </v-btn>
@@ -107,6 +114,7 @@ import { warpHistoryTicketConverter } from "~/utils/warp-history-ticket-converte
 import { _db } from "~/dexie/db"
 import { db } from "~/libs/db/providers"
 import { FirestoreProvider } from "~/libs/firestore/firestore-provider"
+import { buildWarpExport, downloadWarpExport } from "~/utils/warp-export"
 
 usePageTitle(tx("pageTitles.warps"))
 
@@ -207,6 +215,11 @@ const getWarps = async () => {
     fetching.value = false
     error.value = i18n.t("warpsPage.errors.internal")
   })
+}
+
+const exportWarps = () => {
+  const data = buildWarpExport(groupedWarps.value, warpTypes)
+  downloadWarpExport(data)
 }
 
 const clearWarps = () => {

--- a/packages/nuxt/pages/warps.vue
+++ b/packages/nuxt/pages/warps.vue
@@ -50,6 +50,7 @@
         <v-row
           no-gutters
           style="gap: 16px"
+          justify="end"
         >
           <v-spacer />
           <v-btn

--- a/packages/nuxt/public/schemas/warp-export.schema.json
+++ b/packages/nuxt/public/schemas/warp-export.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hsr.matnote.app/schemas/warp-export.schema.json",
+  "title": "WarpExport",
+  "description": "Honkai: Star Rail warp history export format for hsr.matnote.app",
+  "type": "object",
+  "required": ["exportedAt", "schemaVersion", "banners"],
+  "additionalProperties": false,
+  "properties": {
+    "exportedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when the export was created"
+    },
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version number for forward compatibility"
+    },
+    "banners": {
+      "type": "array",
+      "description": "Warp data grouped by banner type",
+      "items": {
+        "$ref": "#/$defs/WarpExportBanner"
+      }
+    }
+  },
+  "$defs": {
+    "WarpExportBanner": {
+      "type": "object",
+      "required": ["type", "name", "currentPityCount5", "currentPityCount4", "warps"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["1", "11", "12", "21", "22"],
+          "description": "Banner type ID"
+        },
+        "name": {
+          "type": "string",
+          "description": "Banner display name"
+        },
+        "currentPityCount5": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Current 5-star pity count (pulls since last 5-star)"
+        },
+        "currentPityCount4": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Current 4-star pity count (pulls since last 4-star)"
+        },
+        "warps": {
+          "type": "array",
+          "description": "Warp history for this banner in chronological order (oldest first)",
+          "items": {
+            "$ref": "#/$defs/WarpExportItem"
+          }
+        }
+      }
+    },
+    "WarpExportItem": {
+      "type": "object",
+      "required": ["id", "gachaType", "time", "name", "itemType", "rankType"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique warp ID assigned by HoYoverse"
+        },
+        "gachaType": {
+          "type": "string",
+          "enum": ["1", "11", "12", "21", "22"],
+          "description": "Banner type ID"
+        },
+        "time": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$",
+          "description": "Date and time of the warp in format yyyy-MM-dd HH:mm:ss (server time)"
+        },
+        "name": {
+          "type": "string",
+          "description": "Character or light cone name in Japanese"
+        },
+        "itemType": {
+          "type": "string",
+          "enum": ["キャラクター", "光円錐"],
+          "description": "Item type: キャラクター (character) or 光円錐 (light cone)"
+        },
+        "rankType": {
+          "type": "string",
+          "enum": ["3", "4", "5"],
+          "description": "Rarity: 3, 4, or 5 stars"
+        },
+        "pityCount": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of pulls in this pity cycle up to and including this item. Present only for 4-star and 5-star items."
+        }
+      }
+    }
+  }
+}

--- a/packages/nuxt/public/schemas/warp-export.schema.json
+++ b/packages/nuxt/public/schemas/warp-export.schema.json
@@ -28,7 +28,7 @@
   "$defs": {
     "WarpExportBanner": {
       "type": "object",
-      "required": ["type", "name", "currentPityCount5", "currentPityCount4", "warps"],
+      "required": ["type", "name", "warps"],
       "additionalProperties": false,
       "properties": {
         "type": {
@@ -39,16 +39,6 @@
         "name": {
           "type": "string",
           "description": "Banner display name"
-        },
-        "currentPityCount5": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Current 5-star pity count (pulls since last 5-star)"
-        },
-        "currentPityCount4": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Current 4-star pity count (pulls since last 4-star)"
         },
         "warps": {
           "type": "array",

--- a/packages/nuxt/public/schemas/warp-export.schema.json
+++ b/packages/nuxt/public/schemas/warp-export.schema.json
@@ -81,11 +81,6 @@
           "type": "string",
           "enum": ["3", "4", "5"],
           "description": "Rarity: 3, 4, or 5 stars"
-        },
-        "pityCount": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Number of pulls in this pity cycle up to and including this item. Present only for 4-star and 5-star items."
         }
       }
     }

--- a/packages/nuxt/types/warp-export.ts
+++ b/packages/nuxt/types/warp-export.ts
@@ -5,8 +5,6 @@ export interface WarpExportItem {
   name: string
   itemType: "キャラクター" | "光円錐"
   rankType: string
-  /** Pity count for 4-star and 5-star items; absent for 3-star */
-  pityCount?: number
 }
 
 export interface WarpExportBanner {

--- a/packages/nuxt/types/warp-export.ts
+++ b/packages/nuxt/types/warp-export.ts
@@ -12,10 +12,6 @@ export interface WarpExportItem {
 export interface WarpExportBanner {
   type: string
   name: string
-  /** Pulls since last 5-star */
-  currentPityCount5: number
-  /** Pulls since last 4-star */
-  currentPityCount4: number
   warps: WarpExportItem[]
 }
 

--- a/packages/nuxt/types/warp-export.ts
+++ b/packages/nuxt/types/warp-export.ts
@@ -1,0 +1,27 @@
+export interface WarpExportItem {
+  id: string
+  gachaType: string
+  time: string
+  name: string
+  itemType: "キャラクター" | "光円錐"
+  rankType: string
+  /** Pity count for 4-star and 5-star items; absent for 3-star */
+  pityCount?: number
+}
+
+export interface WarpExportBanner {
+  type: string
+  name: string
+  /** Pulls since last 5-star */
+  currentPityCount5: number
+  /** Pulls since last 4-star */
+  currentPityCount4: number
+  warps: WarpExportItem[]
+}
+
+export interface WarpExport {
+  /** ISO 8601 timestamp */
+  exportedAt: string
+  schemaVersion: 1
+  banners: WarpExportBanner[]
+}

--- a/packages/nuxt/utils/warp-export.ts
+++ b/packages/nuxt/utils/warp-export.ts
@@ -6,26 +6,6 @@ interface BannerConfig {
   title: string
 }
 
-function computePityCounts(warps: Warp[]): { count5: number, count4: number } {
-  let count5 = warps.length
-  let count4 = warps.length
-
-  for (let i = 0; i < warps.length; i++) {
-    const warp = warps[warps.length - 1 - i]
-    if (count5 === warps.length && warp.rankType === "5") {
-      count5 = i
-    }
-    if (count4 === warps.length && warp.rankType === "4") {
-      count4 = i
-    }
-    if (count5 !== warps.length && count4 !== warps.length) {
-      break
-    }
-  }
-
-  return { count5, count4 }
-}
-
 function buildWarpExportItems(warps: Warp[]): WarpExportItem[] {
   const items: WarpExportItem[] = []
   const pityCount: Record<string, number> = { 4: 0, 5: 0 }
@@ -60,13 +40,10 @@ export function buildWarpExport(
 ): WarpExport {
   const banners: WarpExportBanner[] = bannerConfigs.map((config) => {
     const warps = groupedWarps[config.type] ?? []
-    const { count5, count4 } = computePityCounts(warps)
 
     return {
       type: config.type,
       name: config.title,
-      currentPityCount5: count5,
-      currentPityCount4: count4,
       warps: buildWarpExportItems(warps),
     }
   })

--- a/packages/nuxt/utils/warp-export.ts
+++ b/packages/nuxt/utils/warp-export.ts
@@ -1,0 +1,93 @@
+import type { Warp } from "#shared/warp"
+import type { WarpExport, WarpExportBanner, WarpExportItem } from "~/types/warp-export"
+
+interface BannerConfig {
+  type: string
+  title: string
+}
+
+function computePityCounts(warps: Warp[]): { count5: number, count4: number } {
+  let count5 = warps.length
+  let count4 = warps.length
+
+  for (let i = 0; i < warps.length; i++) {
+    const warp = warps[warps.length - 1 - i]
+    if (count5 === warps.length && warp.rankType === "5") {
+      count5 = i
+    }
+    if (count4 === warps.length && warp.rankType === "4") {
+      count4 = i
+    }
+    if (count5 !== warps.length && count4 !== warps.length) {
+      break
+    }
+  }
+
+  return { count5, count4 }
+}
+
+function buildWarpExportItems(warps: Warp[]): WarpExportItem[] {
+  const items: WarpExportItem[] = []
+  const pityCount: Record<string, number> = { 4: 0, 5: 0 }
+
+  for (const warp of warps) {
+    pityCount[4]++
+    pityCount[5]++
+
+    const item: WarpExportItem = {
+      id: warp.id,
+      gachaType: warp.gachaType,
+      time: warp.time,
+      name: warp.name,
+      itemType: warp.itemType,
+      rankType: warp.rankType,
+    }
+
+    if (warp.rankType === "4" || warp.rankType === "5") {
+      item.pityCount = pityCount[warp.rankType]
+      pityCount[warp.rankType] = 0
+    }
+
+    items.push(item)
+  }
+
+  return items
+}
+
+export function buildWarpExport(
+  groupedWarps: Record<string, Warp[]>,
+  bannerConfigs: BannerConfig[],
+): WarpExport {
+  const banners: WarpExportBanner[] = bannerConfigs.map((config) => {
+    const warps = groupedWarps[config.type] ?? []
+    const { count5, count4 } = computePityCounts(warps)
+
+    return {
+      type: config.type,
+      name: config.title,
+      currentPityCount5: count5,
+      currentPityCount4: count4,
+      warps: buildWarpExportItems(warps),
+    }
+  })
+
+  return {
+    exportedAt: new Date().toISOString(),
+    schemaVersion: 1,
+    banners,
+  }
+}
+
+export function downloadWarpExport(data: WarpExport): void {
+  const json = JSON.stringify(data, null, 2)
+  const blob = new Blob([json], { type: "application/json" })
+  const url = URL.createObjectURL(blob)
+
+  const date = new Date().toISOString().slice(0, 10)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = `warp-history-${date}.json`
+  a.click()
+
+  URL.revokeObjectURL(url)
+}

--- a/packages/nuxt/utils/warp-export.ts
+++ b/packages/nuxt/utils/warp-export.ts
@@ -7,31 +7,14 @@ interface BannerConfig {
 }
 
 function buildWarpExportItems(warps: Warp[]): WarpExportItem[] {
-  const items: WarpExportItem[] = []
-  const pityCount: Record<string, number> = { 4: 0, 5: 0 }
-
-  for (const warp of warps) {
-    pityCount[4]++
-    pityCount[5]++
-
-    const item: WarpExportItem = {
-      id: warp.id,
-      gachaType: warp.gachaType,
-      time: warp.time,
-      name: warp.name,
-      itemType: warp.itemType,
-      rankType: warp.rankType,
-    }
-
-    if (warp.rankType === "4" || warp.rankType === "5") {
-      item.pityCount = pityCount[warp.rankType]
-      pityCount[warp.rankType] = 0
-    }
-
-    items.push(item)
-  }
-
-  return items
+  return warps.map(warp => ({
+    id: warp.id,
+    gachaType: warp.gachaType,
+    time: warp.time,
+    name: warp.name,
+    itemType: warp.itemType,
+    rankType: warp.rankType,
+  }))
 }
 
 export function buildWarpExport(


### PR DESCRIPTION
- WarpExport TypeScript 型定義を追加 (types/warp-export.ts)
- JSON Schema ファイルを追加 (public/schemas/warp-export.schema.json)
- エクスポートユーティリティ関数を追加 (utils/warp-export.ts)
- warps.vue にエクスポートボタンを追加
- ja/en i18n 文字列を追加

https://claude.ai/code/session_012XfNxfHkhUMTh1TNUurFZw